### PR TITLE
Do not hang in poll if event loop is destroyed

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -114,7 +114,7 @@ impl<T> Stream for Receiver<T> {
         match self.rx.get_ref().try_recv() {
             Ok(t) => Ok(Async::Ready(Some(t))),
             Err(TryRecvError::Empty) => {
-                self.rx.need_read();
+                try!(self.rx.need_read());
                 Ok(Async::NotReady)
             }
             Err(TryRecvError::Disconnected) => Ok(Async::Ready(None)),

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -73,7 +73,7 @@ impl TcpListener {
             match self.io.get_ref().accept() {
                 Err(e) => {
                     if e.kind() == io::ErrorKind::WouldBlock {
-                        self.io.need_read();
+                        try!(self.io.need_read());
                     }
                     return Err(e)
                 },
@@ -87,7 +87,7 @@ impl TcpListener {
                             });
                         tx.complete(res);
                         Ok(())
-                    });
+                    }).expect("failed to spawn");
                     self.pending_accept = Some(rx);
                     // continue to polling the `rx` at the beginning of the loop
                 }

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -106,7 +106,7 @@ impl UdpSocket {
         match self.io.get_ref().send_to(buf, target) {
             Ok(Some(n)) => Ok(n),
             Ok(None) => {
-                self.io.need_write();
+                try!(self.io.need_write());
                 Err(mio::would_block())
             }
             Err(e) => Err(e),
@@ -149,7 +149,7 @@ impl UdpSocket {
         match self.io.get_ref().recv_from(buf) {
             Ok(Some(n)) => Ok(n),
             Ok(None) => {
-                self.io.need_read();
+                try!(self.io.need_read());
                 Err(mio::would_block())
             }
             Err(e) => Err(e),

--- a/src/reactor/interval.rs
+++ b/src/reactor/interval.rs
@@ -66,10 +66,10 @@ impl Stream for Interval {
         let now = Instant::now();
         if self.next <= now {
             self.next = next_interval(self.next, now, self.interval);
-            self.token.reset_timeout(self.next, &self.handle);
+            try!(self.token.reset_timeout(self.next, &self.handle));
             Ok(Async::Ready(Some(())))
         } else {
-            self.token.update_timeout(&self.handle);
+            try!(self.token.update_timeout(&self.handle));
             Ok(Async::NotReady)
         }
     }
@@ -77,7 +77,8 @@ impl Stream for Interval {
 
 impl Drop for Interval {
     fn drop(&mut self) {
-        self.token.cancel_timeout(&self.handle);
+        // Ignore error
+        drop(self.token.cancel_timeout(&self.handle));
     }
 }
 

--- a/src/reactor/io_token.rs
+++ b/src/reactor/io_token.rs
@@ -71,6 +71,8 @@ impl IoToken {
     /// receive further notifications it will need to call `schedule_read`
     /// again.
     ///
+    /// This function returns an error if reactor is destroyed.
+    ///
     /// > **Note**: This method should generally not be used directly, but
     /// >           rather the `ReadinessStream` type should be used instead.
     ///
@@ -82,8 +84,8 @@ impl IoToken {
     ///
     /// This function will also panic if there is not a currently running future
     /// task.
-    pub fn schedule_read(&self, handle: &Remote) {
-        handle.send(Message::Schedule(self.token, task::park(), Direction::Read));
+    pub fn schedule_read(&self, handle: &Remote) -> io::Result<()> {
+        handle.send(Message::Schedule(self.token, task::park(), Direction::Read))
     }
 
     /// Schedule the current future task to receive a notification when the
@@ -98,6 +100,8 @@ impl IoToken {
     /// receive further notifications it will need to call `schedule_write`
     /// again.
     ///
+    /// This function returns an error if reactor is destroyed.
+    ///
     /// > **Note**: This method should generally not be used directly, but
     /// >           rather the `ReadinessStream` type should be used instead.
     ///
@@ -109,8 +113,8 @@ impl IoToken {
     ///
     /// This function will also panic if there is not a currently running future
     /// task.
-    pub fn schedule_write(&self, handle: &Remote) {
-        handle.send(Message::Schedule(self.token, task::park(), Direction::Write));
+    pub fn schedule_write(&self, handle: &Remote) -> io::Result<()> {
+        handle.send(Message::Schedule(self.token, task::park(), Direction::Write))
     }
 
     /// Unregister all information associated with a token on an event loop,
@@ -127,6 +131,8 @@ impl IoToken {
     /// ensure that the callbacks are **not** invoked, so pending scheduled
     /// callbacks cannot be relied upon to get called.
     ///
+    /// This function returns an error if reactor is destroyed.
+    ///
     /// > **Note**: This method should generally not be used directly, but
     /// >           rather the `ReadinessStream` type should be used instead.
     ///
@@ -135,7 +141,7 @@ impl IoToken {
     /// This function will panic if the event loop this handle is associated
     /// with has gone away, or if there is an error communicating with the event
     /// loop.
-    pub fn drop_source(&self, handle: &Remote) {
-        handle.send(Message::DropSource(self.token));
+    pub fn drop_source(&self, handle: &Remote) -> io::Result<()> {
+        handle.send(Message::DropSource(self.token))
     }
 }

--- a/src/reactor/timeout.rs
+++ b/src/reactor/timeout.rs
@@ -58,7 +58,7 @@ impl Future for Timeout {
         if self.when <= now {
             Ok(Async::Ready(()))
         } else {
-            self.token.update_timeout(&self.handle);
+            try!(self.token.update_timeout(&self.handle));
             Ok(Async::NotReady)
         }
     }
@@ -66,6 +66,7 @@ impl Future for Timeout {
 
 impl Drop for Timeout {
     fn drop(&mut self) {
-        self.token.cancel_timeout(&self.handle);
+        // Ignore error
+        drop(self.token.cancel_timeout(&self.handle));
     }
 }

--- a/src/reactor/timeout_token.rs
+++ b/src/reactor/timeout_token.rs
@@ -25,11 +25,13 @@ impl TimeoutToken {
 
     /// Updates a previously added timeout to notify a new task instead.
     ///
+    /// This function returns an error if reactor is destroyed.
+    ///
     /// # Panics
     ///
     /// This method will panic if the timeout specified was not created by this
     /// loop handle's `add_timeout` method.
-    pub fn update_timeout(&self, handle: &Remote) {
+    pub fn update_timeout(&self, handle: &Remote) -> io::Result<()> {
         handle.send(Message::UpdateTimeout(self.token, task::park()))
     }
 
@@ -39,17 +41,19 @@ impl TimeoutToken {
     ///
     /// This method will panic if the timeout specified was not created by this
     /// loop handle's `add_timeout` method.
-    pub fn reset_timeout(&mut self, at: Instant, handle: &Remote) {
-        handle.send(Message::ResetTimeout(self.token, at));
+    pub fn reset_timeout(&mut self, at: Instant, handle: &Remote) -> io::Result<()> {
+        handle.send(Message::ResetTimeout(self.token, at))
     }
 
     /// Cancel a previously added timeout.
+    ///
+    /// This function returns an error if reactor is destroyed.
     ///
     /// # Panics
     ///
     /// This method will panic if the timeout specified was not created by this
     /// loop handle's `add_timeout` method.
-    pub fn cancel_timeout(&self, handle: &Remote) {
+    pub fn cancel_timeout(&self, handle: &Remote) -> io::Result<()> {
         debug!("cancel timeout {}", self.token);
         handle.send(Message::CancelTimeout(self.token))
     }

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -1,0 +1,32 @@
+extern crate tokio_core;
+extern crate futures;
+
+use tokio_core::reactor::Core;
+use tokio_core::channel::channel;
+
+use futures::stream::Stream;
+
+
+#[test]
+fn recv_after_core_drop() {
+    let core: Core = Core::new().unwrap();
+
+    let (_sender, receiver) = channel::<u32>(&core.handle()).unwrap();
+
+    drop(core);
+
+    assert!(receiver.wait().next().unwrap().is_err());
+}
+
+#[test]
+fn recv_after_core_and_sender_drop() {
+    let core: Core = Core::new().unwrap();
+
+    let (sender, receiver) = channel::<u32>(&core.handle()).unwrap();
+
+    drop(core);
+    drop(sender);
+
+    // although core is dropped, receiver still properly returns EOF
+    assert!(receiver.wait().next().is_none());
+}

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -24,7 +24,7 @@ fn simple() {
             tx2.complete(2);
             Ok(())
         })
-    });
+    }).expect("failed to spawn");
 
     assert_eq!(lp.run(rx1.join(rx2)).unwrap(), (1, 2));
 }
@@ -68,7 +68,7 @@ fn spawn_in_poll() {
                 tx2.complete(2);
                 Ok(())
             })
-        });
+        }).expect("failed to spawn");
         Ok(())
     }));
 


### PR DESCRIPTION
<s>Partial</s> fix for #12.

Edit: updated a patch.

`Loop` destructor marks all loop handles dead, so any further `poll` requests fail (they currently panic, but should probably return an error).

Also `Loop` destructor unparks all tasks waiting for IO on self. It has no effect on tasks bound to self event loop, but tasks running on different executors call `poll` right afterwards, so they
immediately fail instead of hanging.
