### PR TITLE
Add `turn` on `Core` to allow single event loop iterations

### DIFF
--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -2,6 +2,9 @@ extern crate tokio_core;
 extern crate env_logger;
 extern crate futures;
 
+use std::time::Duration;
+use std::sync::mpsc;
+
 use futures::Future;
 use tokio_core::reactor::Core;
 
@@ -24,6 +27,30 @@ fn simple() {
     });
 
     assert_eq!(lp.run(rx1.join(rx2)).unwrap(), (1, 2));
+}
+
+#[test]
+fn simple_core_poll() {
+    drop(env_logger::init());
+    let mut lp = Core::new().unwrap();
+
+    let (tx, rx) = mpsc::channel();
+    let (tx1, tx2) = (tx.clone(), tx.clone());
+
+    lp.turn(Some(Duration::new(0, 0)));
+    lp.handle().spawn(futures::lazy(move || {
+        tx1.send(1).unwrap();
+        Ok(())
+    }));
+    lp.turn(Some(Duration::new(0, 0)));
+    lp.handle().spawn(futures::lazy(move || {
+        tx2.send(2).unwrap();
+        Ok(())
+    }));
+    assert_eq!(rx.try_recv().unwrap(), 1);
+    assert!(rx.try_recv().is_err());
+    lp.turn(Some(Duration::new(0, 0)));
+    assert_eq!(rx.try_recv().unwrap(), 2);
 }
 
 #[test]


### PR DESCRIPTION
This isn't particularly polished, I wanted to get some initial feedback.

Thoughts/notes: (edit: the below are mostly out of date with the reworked implementation)

~~1. it seemed to be more fitting to have `Core` be a `Stream`, because it's basically an infinite iterator, albeit one that can be altered in the middle of iteration (i.e. polling).
2. however, `Core` never actually produces anything, it just returns whether a loop iteration has been successful
3. the piece of code shown at [1](left unchanged) could probably be improved to return an Err when polling, rather than panicking
4. it only makes sense to call `poll` if you've previously called `spawn`
5. it's important that you can call `poll` on `Core` outside of a task, because otherwise you can't spawn new jobs into it~~

[1]

```
err @ Err(_) => {
    err.unwrap();
}
```
