### PR TITLE
Io streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ log = "0.3"
 mio = "0.6"
 scoped-tls = "0.1.0"
 slab = "0.3"
+bytes = { git = "https://github.com/rrichardson/bytes" }
 
 [dev-dependencies]
 env_logger = "0.3"
+tokio-timer = { git = "https://github.com/tokio-rs/tokio-timer" }

--- a/examples/udp_echo.rs
+++ b/examples/udp_echo.rs
@@ -14,6 +14,7 @@ use tokio_core::net::{ UdpSocket, ByteBufPool };
 use tokio_timer::Timer;
 use std::time::Duration;
 use std::sync::Arc;
+use bytes::Buf;
 
 fn main() {
     let mut core = Core::new().unwrap();

--- a/examples/udp_echo.rs
+++ b/examples/udp_echo.rs
@@ -1,0 +1,52 @@
+
+extern crate futures;
+extern crate bytes;
+extern crate tokio_core;
+extern crate tokio_timer;
+
+use std::net::ToSocketAddrs;
+use std::str;
+use futures::Future;
+use futures::stream::Stream;
+use tokio_core::reactor::Core;
+use tokio_core::net::stream::Udp as UdpStream;
+use tokio_core::net::{ UdpSocket, ByteBufPool }; 
+use tokio_timer::Timer;
+use std::time::Duration;
+use std::sync::Arc;
+
+fn main() {
+    let mut core = Core::new().unwrap();
+    let srvaddr = "127.0.0.1:9999".to_socket_addrs().unwrap().next().unwrap();
+    let cliaddr = "127.0.0.1:9998".to_socket_addrs().unwrap().next().unwrap();
+
+    let clipool = ByteBufPool::new(1024 * 8);
+    let srvpool = ByteBufPool::new(1024 * 8);
+
+    let srv = Arc::new(UdpSocket::bind(&srvaddr, &core.handle()).unwrap());
+    let cli = Arc::new(UdpSocket::bind(&cliaddr, &core.handle()).unwrap());
+   
+    let srv2 = srv.clone();
+    let cli2 = cli.clone();
+
+    let srvstream = UdpStream::new(srv, srvpool);
+    let clistream = UdpStream::new(cli, clipool);
+    
+    let app = cli2.send_dgram(b"PING", &srvaddr).and_then(|_| {
+        let server = srvstream.for_each(|(buf, addr)| { 
+            println!("{}", str::from_utf8(buf.bytes()).unwrap());
+            srv2.send_dgram(b"PONG", &addr).map(|_| ()).wait()
+        });
+        let client = clistream.for_each(|(buf, addr)| { 
+            println!("{}", str::from_utf8(buf.bytes()).unwrap());
+            cli2.send_dgram(b"PING", &addr).map(|_| ()).wait()
+        });
+        server.join(client)
+    });
+
+    let timer = Timer::default(); 
+    let wait = timer.timeout(app, Duration::from_millis(500));
+
+    core.run(wait).unwrap();
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@
 extern crate futures;
 extern crate mio;
 extern crate slab;
+extern crate bytes;
 
 #[macro_use]
 extern crate scoped_tls;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -5,7 +5,52 @@
 
 mod tcp;
 mod udp;
+mod stream_udp;
+mod stream_tcp;
+
+use std::io;
+use std::fmt::{self};
+use bytes::{MutByteBuf};
+use bytes::alloc::BufferPool;
 
 pub use self::tcp::{TcpStream, TcpStreamNew};
 pub use self::tcp::{TcpListener, Incoming};
-pub use self::udp::UdpSocket;
+pub use self::udp::{UdpSocket};
+
+
+/// Implementations of futures::streams for TCP and UDP
+pub mod stream {
+    pub use super::stream_udp::UdpStream as Udp;
+    pub use super::stream_tcp::TcpStream as Tcp;
+}
+
+///
+/// ByteBufPool
+/// Example naieve implementation of the BufferPool
+///
+pub struct ByteBufPool {
+    size : usize
+}
+
+impl ByteBufPool {
+    ///contstruct a new Buffer Pool
+    pub fn new(sz : usize) -> ByteBufPool {
+        ByteBufPool {
+            size : sz
+        }
+    }
+}
+
+impl BufferPool for ByteBufPool {
+    type Item = MutByteBuf;
+    fn get(&self) -> Result<Self::Item, io::Error> {
+        Ok(MutByteBuf::with_capacity(self.size))
+    }
+}
+
+
+impl fmt::Debug for ByteBufPool {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ByteBufPool {{ size: {} }}", self.size)
+    }
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -8,10 +8,9 @@ mod udp;
 mod stream_udp;
 mod stream_tcp;
 
-use std::io;
 use std::fmt::{self};
-use bytes::{MutByteBuf};
-use bytes::alloc::BufferPool;
+use bytes::buf::{SliceBuf};
+use bytes::{BufferPool, AllocError};
 
 pub use self::tcp::{TcpStream, TcpStreamNew};
 pub use self::tcp::{TcpListener, Incoming};
@@ -42,9 +41,9 @@ impl ByteBufPool {
 }
 
 impl BufferPool for ByteBufPool {
-    type Item = MutByteBuf;
-    fn get(&self) -> Result<Self::Item, io::Error> {
-        Ok(MutByteBuf::with_capacity(self.size))
+    type Item = SliceBuf;
+    fn get(&self) -> Result<Self::Item, AllocError> {
+        Ok(SliceBuf::with_capacity(self.size))
     }
 }
 

--- a/src/net/stream_tcp.rs
+++ b/src/net/stream_tcp.rs
@@ -1,0 +1,53 @@
+
+use std::io;
+use std::io::{Read};
+
+use net::TcpStream as NetTcpStream;
+use bytes::MutBuf;
+use bytes::alloc::BufferPool;
+use futures::{Async, Poll};
+use futures::stream::Stream;
+
+
+///
+/// TcpStream
+/// Wraps the UdpSocket and provides a `futures::stream::Stream` implementation
+///
+pub struct TcpStream<S : AsRef<NetTcpStream>, B : BufferPool> {
+    socket: S,
+    pool: B,
+}
+
+impl<S : AsRef<NetTcpStream>, B : BufferPool> TcpStream<S, B> {
+    /// Creates a new TcpStream.  The Buffer pool is a factory of fixed sized
+    /// buffers which is leveraged so that the TcpStream may continually produce
+    /// data.
+    pub fn new(socket: S, b: B) -> TcpStream<S, B> {
+        TcpStream {
+            socket: socket,
+            pool: b
+        }
+    }
+}
+
+impl<S : AsRef<NetTcpStream>, B: BufferPool> Stream for TcpStream<S, B> {
+    type Item = B::Item;
+    type Error = io::Error;
+
+    fn poll(& mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        if let Async::NotReady = self.socket.as_ref().poll_read() {
+            return Ok(Async::NotReady)
+        }
+        let mut buf = try!(self.pool.get());
+        match unsafe { self.socket.as_ref().read(buf.mut_bytes()) } {
+            Ok(amt) => { 
+                unsafe { buf.advance(amt) };
+                Ok(Async::Ready(Some(buf))) },
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                Ok(Async::NotReady)
+            },
+            Err(e) => Err(e)
+        }
+    }
+}
+

--- a/src/net/stream_tcp.rs
+++ b/src/net/stream_tcp.rs
@@ -3,8 +3,7 @@ use std::io;
 use std::io::{Read};
 
 use net::TcpStream as NetTcpStream;
-use bytes::MutBuf;
-use bytes::alloc::BufferPool;
+use bytes::{ MutBuf, BufferPool };
 use futures::{Async, Poll};
 use futures::stream::Stream;
 

--- a/src/net/stream_udp.rs
+++ b/src/net/stream_udp.rs
@@ -3,8 +3,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::convert::AsRef;
 use net::{ UdpSocket };
-use bytes::MutBuf;
-use bytes::alloc::BufferPool;
+use bytes::{ MutBuf, BufferPool };
 use futures::{Async, Poll};
 use futures::stream::Stream;
 

--- a/src/net/stream_udp.rs
+++ b/src/net/stream_udp.rs
@@ -1,0 +1,59 @@
+
+use std::io;
+use std::net::SocketAddr;
+use std::convert::AsRef;
+use net::{ UdpSocket };
+use bytes::MutBuf;
+use bytes::alloc::BufferPool;
+use futures::{Async, Poll};
+use futures::stream::Stream;
+
+///
+/// UdpStream
+/// Wraps the UdpSocket and provides a `futures::stream::Stream` implementation
+///
+pub struct UdpStream<S : AsRef<UdpSocket>, B : BufferPool> {
+    socket: S,
+    pool: B,
+}
+
+impl<S : AsRef<UdpSocket>, B : BufferPool, > UdpStream<S, B> {
+    /// Creates a new UdpStream.  The Buffer pool is a factory of fixed sized
+    /// buffers which is leveraged so that the UdpStream may continually produce
+    /// data.
+    pub fn new(socket: S, b: B) -> UdpStream<S, B> {
+        UdpStream {
+            socket: socket,
+            pool: b,
+        }
+    }
+
+    /// Return a reference to the underlying UDP socket
+    pub fn socket<'a>(&'a self) -> &'a S {
+        &self.socket
+    }
+}
+
+impl<S : AsRef<UdpSocket>, B: BufferPool> Stream for UdpStream<S, B> {
+    type Item = (B::Item, SocketAddr);
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        if let Async::NotReady = self.socket.as_ref().poll_read() {
+            return Ok(Async::NotReady)
+        }
+        let mut buf = try!(self.pool.get());
+        let result = unsafe { self.socket.as_ref().recv_from(buf.mut_bytes()) };
+        match result {
+            Ok((amt, addr)) => { 
+                unsafe { buf.advance(amt)};
+                Ok(Async::Ready(Some((buf, addr)))) },
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                Ok(Async::NotReady)
+            },
+            Err(e) => Err(e)
+        }
+    }
+}
+
+

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,8 +1,9 @@
 use std::io;
 use std::net::{self, SocketAddr, Ipv4Addr, Ipv6Addr};
 use std::fmt;
+use std::mem;
 
-use futures::Async;
+use futures::{Future, Async, Poll};
 use mio;
 
 use reactor::{Handle, PollEvented};
@@ -85,6 +86,34 @@ impl UdpSocket {
             Err(e) => Err(e),
         }
     }
+
+    /// Creates a future that will write the entire contents of the buffer `buf` to
+    /// the stream `a` provided.
+    ///
+    /// The returned future will return after data has been written to the outbound
+    /// socket. 
+    /// The future will resolve to the stream as well as the buffer (for reuse if
+    /// needed).
+    ///
+    /// Any error which happens during writing will cause both the stream and the
+    /// buffer to get destroyed.
+    ///
+    /// The `buf` parameter here only requires the `AsRef<[u8]>` trait, which should
+    /// be broadly applicable to accepting data which can be converted to a slice.
+    /// The `Window` struct is also available in this crate to provide a different
+    /// window into a slice if necessary.
+    pub fn send_dgram<'a, T>(&'a self, buf: T, addr : &'a SocketAddr) -> SendDGram<T>
+        where T: AsRef<[u8]>,
+    {
+        SendDGram {
+            state: UdpState::Writing {
+                sock: self,
+                addr: addr,
+                buf: buf,
+            },
+        }
+    }
+
 
     /// Receives data from the socket. On success, returns the number of bytes
     /// read and the address from whence the data came.
@@ -243,11 +272,68 @@ impl UdpSocket {
     }
 }
 
+
 impl fmt::Debug for UdpSocket {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.io.get_ref().fmt(f)
     }
 }
+
+/// A future used to write the entire contents of some data to a stream.
+///
+/// This is created by the [`write_all`] top-level method.
+///
+/// [`write_all`]: fn.write_all.html
+pub struct SendDGram<'a, T> {
+    state: UdpState<'a, T>,
+}
+
+enum UdpState<'a, T> {
+    Writing {
+        sock: &'a UdpSocket,
+        buf: T,
+        addr: &'a SocketAddr,
+    },
+    Empty,
+}
+
+
+fn zero_write() -> io::Error {
+    io::Error::new(io::ErrorKind::WriteZero, "zero-length write")
+}
+
+fn incomplete_write(reason : &str) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, reason)
+}
+
+impl<'a, T> Future for SendDGram<'a, T>
+    where T: AsRef<[u8]>,
+{
+    type Item = T;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<T, io::Error> {
+        match self.state {
+            UdpState::Writing { ref sock, ref buf, ref addr} => {
+                let buf = buf.as_ref();
+                let n = try_nb!(sock.send_to(&buf, addr));
+                if n == 0 {
+                    return Err(zero_write())
+                }
+                if n != buf.len() {
+                    return Err(incomplete_write("Failed to send entire message in datagram"))
+                }
+            }
+            UdpState::Empty => panic!("poll a SendAllTo after it's done"),
+        }
+
+        match mem::replace(&mut self.state, UdpState::Empty) {
+            UdpState::Writing { buf, .. } => Ok((buf).into()),
+            UdpState::Empty => panic!(),
+        }
+    }
+}
+
 
 #[cfg(unix)]
 mod sys {


### PR DESCRIPTION
OK.  There is a lot going on here, I doubt that the code is in the state where it can be merged, but it makes for decent talking points. 

A couple things:  
**1. Pools and Contiguous memory:**
I don't think we should attempt to guarantee contiguous memory between reads of sockets in the stream.  If someone has that specialized of a need, which seems unlikely, they can implement their own buffer pool to do so.  We could probably add a stream-id parameter to BufferPool::get to allow the pool to try to ensure contiguous pools.  

**2.  Naming.**  
My recommendation is that we change the name of tokio-core::net::TcpStream to TcpSocket.  There isn't really anything special about it that makes it a stream anyways. (I know, probably a long shot for many reasons. )
That aside, I have put the futures::streams implementation into `net::stream::{Tcp, Udp}` 
That seemed like a decent spot for them from a namespace point of view. 

**3. Read to completion.**  
This is something I'm not entirely clear on.  If we don't explicitly say that there isn't any data ready for an io source, will we attempt to read from it at the next poller tick?  I was taking the presence of calls to io.need_read(); to indicate that if that isn't set explicitly, Io::poll_read would continue to indicate that data is waiting.  

 This influences the design pretty heavily because if we have to read to completion for a very fast moving data stream,  there are two issues :  
1. We'll need to be able to return arrays of buffers from stream::poll(). 
2. If we continue to read and produce buffers in a loop, we can starve the other futures. 

I implemented poll for both Tcp and Udp under the optimistic assumption that we can fill only a single buffer at a time and come back to it at the next poll tick. 
