### PR TITLE
Little correction of the example

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -23,7 +23,7 @@ fn main() {
     let handle = l.handle();
 
     // Create a TCP listener which will listen for incoming connections
-    let socket = TcpListener::bind(&addr, &l.handle()).unwrap();
+    let socket = TcpListener::bind(&addr, &handle).unwrap();
 
     // Once we've got the TCP listener, inform that we have it
     println!("Listening on: {}", addr);


### PR DESCRIPTION
Instead of calling the method .handle() twice, just re-use the value from above.
