### PR TITLE
rename Read to ReadOnce and expose it

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -3,7 +3,7 @@
 //! Contains various combinators to work with I/O objects and type definitions
 //! as well.
 
-use std::io::{self, Read, Write};
+use std::io;
 
 use futures::{BoxFuture, Async, Poll};
 use futures::stream::BoxStream;
@@ -44,7 +44,7 @@ pub use self::copy::{copy, Copy};
 pub use self::flush::{flush, Flush};
 pub use self::read_exact::{read_exact, ReadExact};
 pub use self::read_to_end::{read_to_end, ReadToEnd};
-pub use self::read::{read, ReadOnce};
+pub use self::read::{read, Read};
 pub use self::read_until::{read_until, ReadUntil};
 pub use self::split::{ReadHalf, WriteHalf};
 pub use self::window::Window;
@@ -61,7 +61,7 @@ pub use self::write_all::{write_all, WriteAll};
 /// value that indicates "would block" the current future's task is arranged to
 /// receive a notification when the method would otherwise not indicate that it
 /// would block.
-pub trait Io: Read + Write {
+pub trait Io: io::Read + io::Write {
     /// Tests to see if this I/O object may be readable.
     ///
     /// This method returns an `Async<()>` indicating whether the object

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -44,7 +44,7 @@ pub use self::copy::{copy, Copy};
 pub use self::flush::{flush, Flush};
 pub use self::read_exact::{read_exact, ReadExact};
 pub use self::read_to_end::{read_to_end, ReadToEnd};
-pub use self::read::read;
+pub use self::read::{read, ReadOnce};
 pub use self::read_until::{read_until, ReadUntil};
 pub use self::split::{ReadHalf, WriteHalf};
 pub use self::window::Window;

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -1,3 +1,4 @@
+use std::io::{Error, Read};
 use std::mem;
 
 use futures::{Future, Poll};
@@ -15,32 +16,32 @@ enum State<R, T> {
 ///
 /// The returned future will resolve to both the I/O stream and the buffer
 /// as well as the number of bytes read once the read operation is completed.
-pub fn read<R, T>(rd: R, buf: T) -> Read<R, T>
-    where R: ::std::io::Read,
+pub fn read<R, T>(rd: R, buf: T) -> ReadOnce<R, T>
+    where R: Read,
           T: AsMut<[u8]>
 {
-    Read { state: State::Pending { rd: rd, buf: buf } }
+    ReadOnce { state: State::Pending { rd: rd, buf: buf } }
 }
 
 /// A future which can be used to easily read available number of bytes to fill
 /// a buffer.
 ///
 /// Created by the [`read`] function.
-pub struct Read<R, T> {
+pub struct ReadOnce<R, T> {
     state: State<R, T>,
 }
 
-impl<R, T> Future for Read<R, T>
-    where R: ::std::io::Read,
+impl<R, T> Future for ReadOnce<R, T>
+    where R: Read,
           T: AsMut<[u8]>
 {
     type Item = (R, T, usize);
-    type Error = ::std::io::Error;
+    type Error = Error;
 
-    fn poll(&mut self) -> Poll<(R, T, usize), ::std::io::Error> {
+    fn poll(&mut self) -> Poll<(R, T, usize), Error> {
         let nread = match self.state {
             State::Pending { ref mut rd, ref mut buf } => try_nb!(rd.read(&mut buf.as_mut()[..])),
-            State::Empty => panic!("poll a Read after it's done"),
+            State::Empty => panic!("poll a ReadOnce after it's done"),
         };
 
         match mem::replace(&mut self.state, State::Empty) {

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -1,4 +1,3 @@
-use std::io::{Error, Read};
 use std::mem;
 
 use futures::{Future, Poll};
@@ -16,32 +15,32 @@ enum State<R, T> {
 ///
 /// The returned future will resolve to both the I/O stream and the buffer
 /// as well as the number of bytes read once the read operation is completed.
-pub fn read<R, T>(rd: R, buf: T) -> ReadOnce<R, T>
-    where R: Read,
+pub fn read<R, T>(rd: R, buf: T) -> Read<R, T>
+    where R: ::std::io::Read,
           T: AsMut<[u8]>
 {
-    ReadOnce { state: State::Pending { rd: rd, buf: buf } }
+    Read { state: State::Pending { rd: rd, buf: buf } }
 }
 
 /// A future which can be used to easily read available number of bytes to fill
 /// a buffer.
 ///
 /// Created by the [`read`] function.
-pub struct ReadOnce<R, T> {
+pub struct Read<R, T> {
     state: State<R, T>,
 }
 
-impl<R, T> Future for ReadOnce<R, T>
-    where R: Read,
+impl<R, T> Future for Read<R, T>
+    where R: ::std::io::Read,
           T: AsMut<[u8]>
 {
     type Item = (R, T, usize);
-    type Error = Error;
+    type Error = ::std::io::Error;
 
-    fn poll(&mut self) -> Poll<(R, T, usize), Error> {
+    fn poll(&mut self) -> Poll<(R, T, usize), ::std::io::Error> {
         let nread = match self.state {
             State::Pending { ref mut rd, ref mut buf } => try_nb!(rd.read(&mut buf.as_mut()[..])),
-            State::Empty => panic!("poll a ReadOnce after it's done"),
+            State::Empty => panic!("poll a Read after it's done"),
         };
 
         match mem::replace(&mut self.state, State::Empty) {


### PR DESCRIPTION
The other read futures (read_exact, read_until, etc.) all expose their
concrete future types so that function signatures can return them, but
until now `read()` didn't. Exposing it with the name "Read" causes
naming conflicts with the std::io::Read trait, so the easiest thing to
do is to just change the name. Importing std::io::Read under a different
name would've been an option too, but that would probably be annoying
for consumers in the same way it's annoying for us.

The original PR (https://github.com/tokio-rs/tokio-core/pull/29) decided
that "read" was a better name than "read_some", so I'm leaving the top
level functions unchanged. I don't have a strong opinion about it one
way or the other, but I _do_ think it's worth bikeshedding a little bit.
Python's asyncio library actually ended up with a very similar issue
around naming inconsistency between the sync and async worlds, and we
can hopefully avoid repeating that: https://bugs.python.org/issue22279
