### PR TITLE
Fix typo in TcpStream and UdpSocket documentation

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -269,7 +269,7 @@ impl TcpStream {
         self.io.poll_read()
     }
 
-    /// Test whether this socket is writey to be written to or not.
+    /// Test whether this socket is ready to be written to or not.
     ///
     /// If the socket is *not* writable then the current task is scheduled to
     /// get a notification when the socket does become writable. That is, this

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -57,7 +57,7 @@ impl UdpSocket {
         self.io.poll_read()
     }
 
-    /// Test whether this socket is writey to be written to or not.
+    /// Test whether this socket is ready to be written to or not.
     ///
     /// If the socket is *not* writable then the current task is scheduled to
     /// get a notification when the socket does become writable. That is, this


### PR DESCRIPTION
Fixed a small typo of 'writey' where it was expected to be 'ready' in TcpStream and UdpSocket documentation.
