### PR TITLE
export framed function from frame module

### DIFF
--- a/src/io/frame.rs
+++ b/src/io/frame.rs
@@ -396,7 +396,7 @@ impl<T: Io, E: Encode> Sink for FramedWrite<T, E> {
 /// A unified `Stream` and `Sink` interface to an underlying `Io` object, using
 /// the `Encode` and `Decode` traits to encode and decode frames.
 ///
-/// You can acquire a `Framd` instance by using the `Io::framed` adapter.
+/// You can acquire a `Framed` instance by using the `Io::framed` adapter.
 pub struct Framed<T, D, E> {
     upstream: T,
     read_state: ReadState,
@@ -427,6 +427,9 @@ impl<T: Io, D: Decode, E: Encode> Sink for Framed<T, D, E> {
     }
 }
 
+/// Constructs an instance of a Framed struct for encoding and decoding
+/// from an `Io` stream a sequence of frame values that implement 
+/// `Decode` and `Encode`
 pub fn framed<T, D, E>(io: T) -> Framed<T, D, E> {
     Framed {
         upstream: io,

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -42,7 +42,7 @@ mod split;
 mod window;
 mod write_all;
 pub use self::copy::{copy, Copy};
-pub use self::frame::{EasyBuf, EasyBufMut, FramedRead, FramedWrite, Framed, Decode, Encode};
+pub use self::frame::{EasyBuf, EasyBufMut, FramedRead, FramedWrite, Framed, Decode, Encode, framed};
 pub use self::flush::{flush, Flush};
 pub use self::read_exact::{read_exact, ReadExact};
 pub use self::read_to_end::{read_to_end, ReadToEnd};


### PR DESCRIPTION
The frame module is private so the framed constructor function isn't visible.
This makes it public by explicitly exporting it from the io module.