### PR TITLE
Add From<Vec<u8>> and Clone impls to EasyBuf

### DIFF
--- a/src/io/frame.rs
+++ b/src/io/frame.rs
@@ -12,6 +12,7 @@ use io::Io;
 /// be handed out efficiently, each with a `'static` lifetime which keeps the
 /// data alive. The buffer also supports mutation but may require bytes to be
 /// copied to complete the operation.
+#[derive(Clone)]
 pub struct EasyBuf {
     buf: Arc<Vec<u8>>,
     start: usize,

--- a/src/io/frame.rs
+++ b/src/io/frame.rs
@@ -177,6 +177,17 @@ impl<'a> DerefMut for EasyBufMut<'a> {
     }
 }
 
+impl From<Vec<u8>> for EasyBuf {
+    fn from(vec: Vec<u8>) -> EasyBuf {
+        let end = vec.len();
+        EasyBuf {
+            buf: Arc::new(vec),
+            start: 0,
+            end: end,
+        }
+    }
+}
+
 impl<'a> Drop for EasyBufMut<'a> {
     fn drop(&mut self) {
         *self.end = self.buf.len();


### PR DESCRIPTION
A couple things I've run into while working on docs.