### PR TITLE
UDP Codec Example Tweaks

### DIFF
--- a/examples/udp-codec.rs
+++ b/examples/udp-codec.rs
@@ -28,9 +28,7 @@ impl UdpCodec for LineCodec {
         Ok((*addr, buf.to_vec()))
     }
 
-    fn encode(&mut self,
-              (addr, buf): (SocketAddr, Vec<u8>),
-              into: &mut Vec<u8>) -> SocketAddr {
+    fn encode(&mut self, (addr, buf): Self::Out, into: &mut Vec<u8>) -> SocketAddr {
         into.extend(buf);
         return addr
     }

--- a/examples/udp-codec.rs
+++ b/examples/udp-codec.rs
@@ -30,7 +30,7 @@ impl UdpCodec for LineCodec {
 
     fn encode(&mut self, (addr, buf): Self::Out, into: &mut Vec<u8>) -> SocketAddr {
         into.extend(buf);
-        return addr
+        addr
     }
 }
 


### PR DESCRIPTION
I think these are pretty obvious, but just in case: The first commit uses the `Self::Out` type in the function signature of `encode` rather than an explicit tuple that happens to have the same type, I think it makes it more obvious what the intention is. The second removes a `return` that didn't actually have a semicolon after the statement anyway.