### PR TITLE
Fix typo in non-doc comment in copy.rs

### DIFF
--- a/src/io/copy.rs
+++ b/src/io/copy.rs
@@ -72,7 +72,7 @@ impl<R, W> Future for Copy<R, W>
                 self.amt += i as u64;
             }
 
-            // If we've written al the data and we've seen EOF, flush out the
+            // If we've written all the data and we've seen EOF, flush out the
             // data and finish the transfer.
             // done with the entire transfer.
             if self.pos == self.cap && self.read_done {


### PR DESCRIPTION
(feel free to not merge this since it's not a fix for a comment in public docs!)