### PR TITLE
rename sock -> listener in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,10 +57,10 @@
 //!
 //!     // Bind the server's socket
 //!     let addr = "127.0.0.1:12345".parse().unwrap();
-//!     let sock = TcpListener::bind(&addr, &handle).unwrap();
+//!     let listener = TcpListener::bind(&addr, &handle).unwrap();
 //!
 //!     // Pull out a stream of sockets for incoming connections
-//!     let server = sock.incoming().for_each(|(sock, _)| {
+//!     let server = listener.incoming().for_each(|(sock, _)| {
 //!         // Split up the reading and writing parts of the
 //!         // socket
 //!         let (reader, writer) = sock.split();


### PR DESCRIPTION
Makes it much clearer for someone fairly new to rust and tokio (like me) to follow along when the same named variable aren't totally different things :)