### PR TITLE
small typo fixed for io module

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -64,7 +64,7 @@ pub use self::write_all::{write_all, WriteAll};
 
 /// A trait for read/write I/O objects
 ///
-/// This trait represents I/O object which are readable and writable.
+/// This trait represents I/O objects which are readable and writable.
 /// Additionally, they're associated with the ability to test whether they're
 /// readable or writable.
 ///


### PR DESCRIPTION
Just a very tiny typo fixed. "objects" should be plural in that sentence"