### PR TITLE
Add support for a default thread per core

### DIFF
--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -54,7 +54,11 @@ thread_local!(static DEFAULT_CORE_AND_HANDLE: CoreAndHandle = {
 
 /// Get a mutable reference to the default core.
 pub fn with_default_core<T, F: FnOnce(&mut Core) -> T>(cls: F) -> T {
-    DEFAULT_CORE_AND_HANDLE.with(|o| cls(&mut *o.core.borrow_mut()))
+    DEFAULT_CORE_AND_HANDLE.with(|o|
+        cls(&mut *o.core.try_borrow_mut().expect(
+            "could not borrow default core, already borrowed (event loop running?)"
+        ))
+    )
 }
 
 /// Shortcut for runnign the default event loop. Takes a future, which is passed

--- a/tests/default-core.rs
+++ b/tests/default-core.rs
@@ -2,6 +2,7 @@ extern crate tokio_core;
 use tokio_core::reactor;
 
 extern crate futures;
+use futures::empty;
 use futures::future::Future;
 
 use std::thread;
@@ -36,4 +37,14 @@ fn default_core_in_another_thread() {
 
         assert_eq!(result.unwrap(), val);
     }).join();
+}
+
+#[test]
+#[should_panic(expected = "could not borrow default core, already borrowed (event loop running?)")]
+fn running_core_inside_running_core_panics() {
+    reactor::default_handle().spawn(reactor::Timeout::new(
+        Duration::from_millis(50),
+        &reactor::default_handle()
+    ).unwrap().then(|_| reactor::run_default(empty::<(), ()>())));
+    reactor::run_default(empty::<(), ()>());
 }

--- a/tests/default-core.rs
+++ b/tests/default-core.rs
@@ -1,0 +1,39 @@
+extern crate tokio_core;
+use tokio_core::reactor;
+
+extern crate futures;
+use futures::future::Future;
+
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn default_core() {
+
+    let val = 10;
+
+    let timeout = reactor::Timeout::new(
+        Duration::from_millis(10),
+        &reactor::default_handle()
+    ).unwrap().map(|_| val);
+
+    let result = reactor::with_default_core(|core| core.run(timeout));
+
+    assert_eq!(result.unwrap(), val);
+}
+
+#[test]
+fn default_core_in_another_thread() {
+    thread::spawn(move || {
+        let val = 10;
+
+        let timeout = reactor::Timeout::new(
+            Duration::from_millis(10),
+            &reactor::default_handle()
+        ).unwrap().map(|_| val);
+
+        let result = reactor::run_default(timeout);
+
+        assert_eq!(result.unwrap(), val);
+    }).join();
+}


### PR DESCRIPTION
This adds a thread local variable that is lazily initialized to a
default core and handle for that core. It also proposes three api
methods for interacting with that core:

    // get a mutable reference to the core in a callback
    tokio::reactor::with_default_core(|core| ... );

    // run the core (in this case indefinitely)
    tokio::reactor::run_default(future::empty());

    // get a handle to the core - in this case for setting a timeout
    let timeout = tokio::reactor::Timeout::new(
        Duration::from_millis(100),
        &tokio::reactor::default_handle()
    );

The purpose of this proposed change is to make it so that libraries
based on tokio can use this by default to make the dominant use-case
(one event loop per thread) more ergonomic - something like:

    // imagined api
    my_network_service.init(None);
    tokio::reactor::run_default(future::empty());

    // or using a non-default core:
    my_network_service.init(Some(core.handle()));
    core.run(future::empty())