### PR TITLE
make TcpStream::flush() a noop

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -505,7 +505,7 @@ impl Write for TcpStream {
         self.io.write(buf)
     }
     fn flush(&mut self) -> io::Result<()> {
-        self.io.flush()
+        Ok(())
     }
 }
 


### PR DESCRIPTION
`std::net::TcpStream::flush` is at the end of the current call chain, and it does nothing. However, the wrapper in tokio-core does an atomic compare for write readiness before calling in to the noop. This actually shows up in profiles, and since it does nothing in the end, let's skip the atomic operations.