### PR TITLE
[fuchsia] Config changes to build on Fuchsia

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ appveyor = { repository = "alexcrichton/tokio-core" }
 [dependencies]
 bytes = "0.4"
 log = "0.3"
-mio = "0.6.9"
+mio = "0.6.10"
 scoped-tls = "0.1.0"
 slab = "0.3"
 iovec = "0.1"

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -706,7 +706,7 @@ impl Future for TcpStreamNewState {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "fuchsia")))]
 mod sys {
     use std::os::unix::prelude::*;
     use super::{TcpStream, TcpListener};

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -415,7 +415,7 @@ impl<T> Future for RecvDgram<T>
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "fuchsia")))]
 mod sys {
     use std::os::unix::prelude::*;
     use super::UdpSocket;

--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -820,7 +820,7 @@ fn usize2ready(bits: usize) -> mio::Ready {
     ready | platform::usize2ready(bits)
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "fuchsia")))]
 mod platform {
     use mio::Ready;
     use mio::unix::UnixReady;
@@ -871,7 +871,7 @@ mod platform {
     }
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, target_os = "fuchsia"))]
 mod platform {
     use mio::Ready;
 


### PR DESCRIPTION
This patch disables various Unix-specific platform features that are not enabled on Fuchsia. It also updates the mio version to 0.6.10, which is the first release that supports Fuchsia.