### PR TITLE
Prefer ErrorKind::WouldBlock

### DIFF
--- a/src/io/split.rs
+++ b/src/io/split.rs
@@ -46,7 +46,7 @@ impl<T: Read> Read for ReadHalf<T> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self.handle.poll_lock() {
             Async::Ready(mut l) => l.read(buf),
-            Async::NotReady => Err(::would_block()),
+            Async::NotReady => Err(io::ErrorKind::WouldBlock.into()),
         }
     }
 }
@@ -55,14 +55,14 @@ impl<T: Write> Write for WriteHalf<T> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self.handle.poll_lock() {
             Async::Ready(mut l) => l.write(buf),
-            Async::NotReady => Err(::would_block()),
+            Async::NotReady => Err(io::ErrorKind::WouldBlock.into()),
         }
     }
 
     fn flush(&mut self) -> io::Result<()> {
         match self.handle.poll_lock() {
             Async::Ready(mut l) => l.flush(),
-            Async::NotReady => Err(::would_block()),
+            Async::NotReady => Err(io::ErrorKind::WouldBlock.into()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,9 +115,3 @@ mod heap;
 pub mod channel;
 pub mod net;
 pub mod reactor;
-
-use std::io as sio;
-
-fn would_block() -> sio::Error {
-    sio::Error::new(sio::ErrorKind::WouldBlock, "would block")
-}

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -63,7 +63,7 @@ impl TcpListener {
                 match pending.poll().expect("shouldn't be canceled") {
                     Async::NotReady => {
                         self.pending_accept = Some(pending);
-                        return Err(::would_block())
+                        return Err(io::ErrorKind::WouldBlock.into())
                     },
                     Async::Ready(r) => return r,
                 }
@@ -541,7 +541,7 @@ impl ::io::Io for TcpStream {
 
     fn read_vec(&mut self, bufs: &mut [&mut IoVec]) -> io::Result<usize> {
         if let Async::NotReady = <TcpStream>::poll_read(self) {
-            return Err(::would_block())
+            return Err(io::ErrorKind::WouldBlock.into())
         }
         let r = self.io.get_ref().read_bufs(bufs);
         if is_wouldblock(&r) {
@@ -552,7 +552,7 @@ impl ::io::Io for TcpStream {
 
     fn write_vec(&mut self, bufs: &[&IoVec]) -> io::Result<usize> {
         if let Async::NotReady = <TcpStream>::poll_write(self) {
-            return Err(::would_block())
+            return Err(io::ErrorKind::WouldBlock.into())
         }
         let r = self.io.get_ref().write_bufs(bufs);
         if is_wouldblock(&r) {

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -101,7 +101,7 @@ impl UdpSocket {
     /// documentation for concrete examples.
     pub fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
         if let Async::NotReady = self.io.poll_write() {
-            return Err(::would_block())
+            return Err(io::ErrorKind::WouldBlock.into())
         }
         match self.io.get_ref().send_to(buf, target) {
             Ok(n) => Ok(n),
@@ -145,7 +145,7 @@ impl UdpSocket {
     /// read and the address from whence the data came.
     pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         if let Async::NotReady = self.io.poll_read() {
-            return Err(::would_block())
+            return Err(io::ErrorKind::WouldBlock.into())
         }
         match self.io.get_ref().recv_from(buf) {
             Ok(n) => Ok(n),

--- a/src/reactor/poll_evented.rs
+++ b/src/reactor/poll_evented.rs
@@ -274,7 +274,7 @@ impl<E> PollEvented<E> {
 impl<E: Read> Read for PollEvented<E> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if let Async::NotReady = self.poll_read() {
-            return Err(::would_block())
+            return Err(io::ErrorKind::WouldBlock.into())
         }
         let r = self.get_mut().read(buf);
         if is_wouldblock(&r) {
@@ -287,7 +287,7 @@ impl<E: Read> Read for PollEvented<E> {
 impl<E: Write> Write for PollEvented<E> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if let Async::NotReady = self.poll_write() {
-            return Err(::would_block())
+            return Err(io::ErrorKind::WouldBlock.into())
         }
         let r = self.get_mut().write(buf);
         if is_wouldblock(&r) {
@@ -298,7 +298,7 @@ impl<E: Write> Write for PollEvented<E> {
 
     fn flush(&mut self) -> io::Result<()> {
         if let Async::NotReady = self.poll_write() {
-            return Err(::would_block())
+            return Err(io::ErrorKind::WouldBlock.into())
         }
         let r = self.get_mut().flush();
         if is_wouldblock(&r) {
@@ -333,7 +333,7 @@ impl<'a, E> Read for &'a PollEvented<E>
 {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if let Async::NotReady = self.poll_read() {
-            return Err(::would_block())
+            return Err(io::ErrorKind::WouldBlock.into())
         }
         let r = self.get_ref().read(buf);
         if is_wouldblock(&r) {
@@ -348,7 +348,7 @@ impl<'a, E> Write for &'a PollEvented<E>
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if let Async::NotReady = self.poll_write() {
-            return Err(::would_block())
+            return Err(io::ErrorKind::WouldBlock.into())
         }
         let r = self.get_ref().write(buf);
         if is_wouldblock(&r) {
@@ -359,7 +359,7 @@ impl<'a, E> Write for &'a PollEvented<E>
 
     fn flush(&mut self) -> io::Result<()> {
         if let Async::NotReady = self.poll_write() {
-            return Err(::would_block())
+            return Err(io::ErrorKind::WouldBlock.into())
         }
         let r = self.get_ref().flush();
         if is_wouldblock(&r) {


### PR DESCRIPTION
fix #216

This is probably measurable in practice

```
pub fn before() -> io::Error {
    io::Error::new(io::ErrorKind::WouldBlock, "would block")
}

pub fn after() -> io::Error {
    io::ErrorKind::WouldBlock.into()
}

example::before:
        push    rbp
        mov     rbp, rsp
        push    rbx
        push    rax
        mov     rbx, rdi
        lea     rdi, [rip + str.0]
        mov     esi, 11
        call    std::error::<impl core::convert::From<&'b str> for alloc::boxed::Box<std::error::Error + core::marker::Sync + core::marker::Send + 'a>>::from@PLT
        mov     rcx, rdx
        mov     esi, 10
        mov     rdi, rbx
        mov     rdx, rax
        call    std::io::error::Error::_new@PLT
        mov     rax, rbx
        add     rsp, 8
        pop     rbx
        pop     rbp
        ret

example::after:
        push    rbp
        mov     rbp, rsp
        mov     word ptr [rdi], 2561
        mov     rax, rdi
        pop     rbp
        ret

str.0:
        .ascii  "would block"
```