### PR TITLE
TokenTimeout: add doc around new panic

### DIFF
--- a/src/reactor/timeout_token.rs
+++ b/src/reactor/timeout_token.rs
@@ -48,7 +48,7 @@ impl TimeoutToken {
     /// # Panics
     ///
     /// This method will panic if the timeout specified was not created by this
-    /// loop handle's `add_timeout` method.
+    /// loop handle's `add_timeout` method or if called multiple times.
     pub fn cancel_timeout(&self, handle: &Remote) {
         debug!("cancel timeout {}", self.token);
         handle.send(Message::CancelTimeout(self.token))


### PR DESCRIPTION
My slab bump in #246 added a potential new panic in Core's Inner's
`cancel_timeout`.

Thankfully, the only way `cancel_timeout` can be called is from
TimeoutToken's `cancel_timeout`, which is crate-internal only and is
only called from Timeout's and Interval's drop fn's.

This change simply adds new clarifying documentation around
TokenTimeout's cancel_timeout to "future proof" anybody looking to use
cancel_timeout directly (not just on drop).