### PR TITLE
bump futures to 0.1.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ scoped-tls = "0.1.0"
 slab = "0.4"
 iovec = "0.1"
 tokio-io = "0.1"
-futures = "0.1.15"
+futures = "0.1.16"
 
 [dev-dependencies]
 env_logger = { version = "0.4", default-features = false }


### PR DESCRIPTION
examples/tinydb.rs uses futures::prelude, which was added in 0.1.16