### PR TITLE
Add Fuchsia-specific reactor and net impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,19 @@ appveyor = { repository = "alexcrichton/tokio-core" }
 [dependencies]
 bytes = "0.4"
 log = "0.3"
-mio = "0.6.10"
 scoped-tls = "0.1.0"
 slab = "0.4"
 iovec = "0.1"
 tokio-io = "0.1"
 futures = "0.1.16"
+
+[target.'cfg(not(target_os = "fuchsia"))'.dependencies]
+mio = "0.6.10"
+
+[target.'cfg(target_os = "fuchsia")'.dependencies]
+fuchsia-zircon = "0.3.2"
+libc = "0.2.34"
+net2 = "0.2.29"
 
 [dev-dependencies]
 env_logger = { version = "0.4", default-features = false }
@@ -32,7 +39,7 @@ flate2 = { version = "0.2", features = ["tokio"] }
 futures-cpupool = "0.1"
 http = "0.1"
 httparse = "1.0"
-libc = "0.2"
+libc = "0.2.34"
 num_cpus = "1.0"
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,9 +98,18 @@ extern crate bytes;
 #[macro_use]
 extern crate futures;
 extern crate iovec;
-extern crate mio;
 extern crate slab;
 extern crate tokio_io;
+
+#[cfg(not(target_os = "fuchsia"))]
+extern crate mio;
+
+#[cfg(target_os = "fuchsia")]
+extern crate fuchsia_zircon as zx;
+#[cfg(target_os = "fuchsia")]
+extern crate libc;
+#[cfg(target_os = "fuchsia")]
+extern crate net2;
 
 #[macro_use]
 extern crate scoped_tls;
@@ -112,8 +121,17 @@ extern crate log;
 #[doc(hidden)]
 pub mod io;
 
+#[cfg(not(target_os = "fuchsia"))]
 mod heap;
 #[doc(hidden)]
 pub mod channel;
 pub mod net;
+
 pub mod reactor;
+
+fn is_wouldblock<T>(r: &::std::io::Result<T>) -> bool {
+    match *r {
+        Ok(_) => false,
+        Err(ref e) => e.kind() == ::std::io::ErrorKind::WouldBlock,
+    }
+}

--- a/src/net/fuchsia/mod.rs
+++ b/src/net/fuchsia/mod.rs
@@ -1,0 +1,369 @@
+mod tcp;
+pub(crate) use self::tcp::{TcpListener, TcpStream};
+
+mod udp;
+pub(crate) use self::udp::UdpSocket;
+
+use futures::Async;
+use futures::task::AtomicTask;
+use libc;
+use zx::{self, AsHandleRef};
+
+use std::io::{self, Read, Write};
+use std::mem;
+use std::net::{self, SocketAddr};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use reactor::{self, PacketReceiver, ReceiverRegistration};
+use is_wouldblock;
+
+const READABLE: usize = libc::EPOLLIN as usize;
+const WRITABLE: usize = libc::EPOLLOUT as usize;
+const ERROR: usize    = libc::EPOLLERR as usize;
+const HUP: usize      = libc::EPOLLHUP as usize;
+
+// Unsafe to use. `receive_packet` must not be called after
+// `fdio` is invalidated.
+pub(crate) struct EventedFdPacketReceiver {
+    fdio: *const syscall::fdio_t,
+    signals: AtomicUsize,
+    read_task: AtomicTask,
+    write_task: AtomicTask,
+}
+
+// Needed because of the fdio pointer.
+// It is safe to send because the `EventedFdPacketReceiver` must be
+// deregistered (and therefore `receive_packet` never called again)
+// before `__fdio_release` is called.
+unsafe impl Send for EventedFdPacketReceiver {}
+unsafe impl Sync for EventedFdPacketReceiver {}
+
+impl PacketReceiver for EventedFdPacketReceiver {
+    fn receive_packet(&self, packet: zx::Packet) {
+        let observed_signals = if let zx::PacketContents::SignalOne(p) = packet.contents() {
+            p.observed()
+        } else { return };
+
+        let mut events: u32 = 0;
+        unsafe {
+            syscall::__fdio_wait_end(self.fdio, observed_signals.bits(), &mut events);
+        }
+        let events = events as usize;
+
+        let old = self.signals.fetch_or(events, Ordering::SeqCst);
+        let became_readable = ((events & READABLE) != 0) && ((old & READABLE) == 0);
+        let became_writable = ((events & WRITABLE) != 0) && ((old & WRITABLE) == 0);
+        let err_occurred = (events &(ERROR | HUP)) != 0;
+
+        if became_readable || err_occurred {
+            self.read_task.notify();
+        }
+        if became_writable || err_occurred {
+            self.write_task.notify();
+        }
+    }
+}
+
+/// A type which can be used for receiving IO events for a file descriptor.
+pub(crate) struct EventedFd<T> {
+    inner: T,
+    // Must be valid, acquired from `__fdio_to_io`
+    fdio: *const syscall::fdio_t,
+    // Must be dropped before `__fdio_release` is called
+    signal_receiver: mem::ManuallyDrop<ReceiverRegistration<EventedFdPacketReceiver>>,
+}
+
+unsafe impl<T> Send for EventedFd<T> where T: Send {}
+unsafe impl<T> Sync for EventedFd<T> where T: Sync {}
+
+impl<T> Drop for EventedFd<T> {
+    fn drop(&mut self) {
+        unsafe {
+            // Drop the receiver so `packet_receive` may not be called again.
+            mem::ManuallyDrop::drop(&mut self.signal_receiver);
+
+            // Release the fdio
+            syscall::__fdio_release(self.fdio);
+        }
+
+        // Then `inner` gets dropped
+    }
+}
+
+impl<T> EventedFd<T> where T: AsRawFd {
+    /// Creates a new EventedFd.
+    ///
+    /// For this function to be safe, the underlying file descriptor from `T::as_raw_fd`
+    /// must be a valid file descriptor which remains valid for the duration of `T`'s
+    /// lifetime.
+    pub unsafe fn new(inner: T, remote: &reactor::Remote) -> io::Result<Self> {
+        let fdio = syscall::__fdio_fd_to_io(inner.as_raw_fd());
+        let signal_receiver = remote.register_packet_receiver(Arc::new(EventedFdPacketReceiver {
+            fdio,
+            signals: AtomicUsize::new(0),
+            read_task: AtomicTask::new(),
+            write_task: AtomicTask::new(),
+        }));
+
+        let evented_fd = EventedFd {
+            inner,
+            fdio,
+            signal_receiver: mem::ManuallyDrop::new(signal_receiver),
+        };
+
+        // Make sure a packet is delivered if an error or closure occurs.
+        evented_fd.schedule_packet(ERROR | HUP);
+
+        // Need to schedule packets to maintain the invariant that
+        // if !READABLE or !WRITABLE a packet has been scheduled.
+        evented_fd.schedule_packet(READABLE);
+        evented_fd.schedule_packet(WRITABLE);
+
+        Ok(evented_fd)
+    }
+    /// Tests to see if this resource is ready to be read from.
+    /// If it is not, it arranges for the current task to receive a notification
+    /// when a "writable" signal arrives.
+    pub fn poll_read(&self) -> Async<()> {
+        let receiver = self.signal_receiver.receiver();
+        if (receiver.signals.load(Ordering::SeqCst) &
+            (READABLE | ERROR | HUP)) != 0
+        {
+            Async::Ready(())
+        } else {
+            self.need_read();
+            Async::NotReady
+        }
+    }
+
+    /// Tests to see if this resource is ready to be written to.
+    /// If it is not, it arranges for the current task to receive a notification
+    /// when a "writable" signal arrives.
+    pub fn poll_write(&self) -> Async<()> {
+        let receiver = self.signal_receiver.receiver();
+        if (receiver.signals.load(Ordering::SeqCst) &
+            (WRITABLE | ERROR | HUP)) != 0
+        {
+            Async::Ready(())
+        } else {
+            self.need_write();
+            Async::NotReady
+        }
+    }
+
+    // Returns a reference to the underlying IO object.
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    // Returns a mutable reference to the underlying IO object.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Arranges for the current task to receive a notification when a "readable"
+    /// signal arrives.
+    pub fn need_read(&self) {
+        let receiver = self.signal_receiver.receiver();
+        receiver.read_task.register();
+        let old = receiver.signals.fetch_and(!READABLE, Ordering::SeqCst);
+        // We only need to schedule a new packet if one isn't already scheduled.
+        // If READABLE was already false, a packet was already scheduled.
+        if (old & READABLE) != 0 {
+            self.schedule_packet(READABLE);
+        }
+    }
+
+    /// Arranges for the current task to receive a notification when a "writable"
+    /// signal arrives.
+    pub fn need_write(&self) {
+        let receiver = self.signal_receiver.receiver();
+        receiver.write_task.register();
+        let old = receiver.signals.fetch_and(!WRITABLE, Ordering::SeqCst);
+        // We only need to schedule a new packet if one isn't already scheduled.
+        // If WRITABLE was already false, a packet was already scheduled.
+        if (old & WRITABLE) != 0 {
+            self.schedule_packet(WRITABLE);
+        }
+    }
+
+    fn schedule_packet(&self, signals: usize) {
+        unsafe {
+            let (mut raw_handle, mut raw_signals) = mem::uninitialized();
+            syscall::__fdio_wait_begin(
+                self.fdio,
+                signals as u32,
+                &mut raw_handle,
+                &mut raw_signals,
+            );
+
+            let handle = zx::Handle::from_raw(raw_handle);
+            let signals = zx::Signals::from_bits_truncate(raw_signals);
+
+            let res = handle.wait_async_handle(
+                self.signal_receiver.remote().port(),
+                self.signal_receiver.key(),
+                signals,
+                zx::WaitAsyncOpts::Once,
+            );
+
+            // The handle is borrowed, so we cannot drop it.
+            mem::forget(handle);
+            res.expect("Error scheduling EventedFd notification");
+        }
+    }
+
+    /// Clears all incoming signals.
+    pub fn clear(&self) {
+        self.signal_receiver.receiver().signals.store(0, Ordering::SeqCst);
+    }
+
+    /// Get a reference to the event loop with which this `EventedFd` was created.
+    pub fn remote(&self) -> &reactor::Remote {
+        self.signal_receiver.remote()
+    }
+}
+
+impl<T: AsRawFd> AsRawFd for EventedFd<T> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.get_ref().as_raw_fd()
+    }
+}
+
+impl<T: Read + AsRawFd> Read for EventedFd<T> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_mut().read(buf);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        r
+    }
+}
+
+impl<T: Write + AsRawFd> Write for EventedFd<T> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if let Async::NotReady = self.poll_write() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_mut().write(buf);
+        if is_wouldblock(&r) {
+            self.need_write();
+        }
+        r
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if let Async::NotReady = self.poll_write() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_mut().flush();
+        if is_wouldblock(&r) {
+            self.need_write();
+        }
+        r
+    }
+}
+
+impl<'a, T: AsRawFd> Read for &'a EventedFd<T>
+    where &'a T: Read
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if let Async::NotReady = self.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().read(buf);
+        if is_wouldblock(&r) {
+            self.need_read();
+        }
+        r
+    }
+}
+
+impl<'a, T: AsRawFd> Write for &'a EventedFd<T>
+    where &'a T: Write
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if let Async::NotReady = self.poll_write() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().write(buf);
+        if is_wouldblock(&r) {
+            self.need_write();
+        }
+        r
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if let Async::NotReady = self.poll_write() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+        let r = self.get_ref().flush();
+        if is_wouldblock(&r) {
+            self.need_write();
+        }
+        r
+    }
+}
+
+mod syscall {
+    #![allow(non_camel_case_types, improper_ctypes)]
+    use std::os::unix::io::RawFd;
+    pub use zx::sys::{zx_handle_t, zx_signals_t};
+
+    // This is the "improper" c type
+    pub type fdio_t = ();
+
+    #[link(name = "fdio")]
+    extern {
+        pub fn __fdio_fd_to_io(fd: RawFd) -> *const fdio_t;
+        pub fn __fdio_release(io: *const fdio_t);
+
+        pub fn __fdio_wait_begin(
+            io: *const fdio_t,
+            events: u32,
+            handle_out: &mut zx_handle_t,
+            signals_out: &mut zx_signals_t,
+        );
+
+        pub fn __fdio_wait_end(
+            io: *const fdio_t,
+            signals: zx_signals_t,
+            events_out: &mut u32,
+        );
+    }
+}
+
+// Set non-blocking (workaround since the std version doesn't work in fuchsia)
+// TODO: fix the std version and replace this
+pub fn set_nonblock(fd: RawFd) -> io::Result<()> {
+    let res = unsafe { libc::fcntl(fd, libc::F_SETFL, libc::O_NONBLOCK) };
+    if res == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+/// Workaround until fuchsia's recv_from is fixed
+unsafe fn recv_from(fd: RawFd, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+    let flags = 0;
+
+    let n = 
+        libc::recv(fd,
+                   buf.as_mut_ptr() as *mut libc::c_void,
+                   buf.len(),
+                   flags);
+
+    if n == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // random address-- we don't use it
+    let addr = SocketAddr::new(net::IpAddr::V4(net::Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    Ok((n as usize, addr))
+}

--- a/src/net/fuchsia/tcp.rs
+++ b/src/net/fuchsia/tcp.rs
@@ -1,0 +1,165 @@
+use std::io::{self, Read, Write};
+use std::net::{self, SocketAddr};
+use std::ops::Deref;
+use bytes::{Buf, BufMut};
+use futures::{Poll, Async};
+
+use std::os::unix::io::AsRawFd;
+
+use libc;
+use net2::{TcpBuilder, TcpStreamExt};
+
+use net::fuchsia::{EventedFd, set_nonblock};
+
+use reactor::{Handle, Remote};
+
+/// An I/O object representing a TCP socket listening for incoming connections.
+///
+/// This object can be converted into a stream of incoming connections for
+/// various forms of processing.
+pub(crate) struct TcpListener(EventedFd<net::TcpListener>);
+
+impl Deref for TcpListener {
+    type Target = EventedFd<net::TcpListener>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl TcpListener {
+    pub fn bind(addr: &SocketAddr, handle: &Handle) -> io::Result<TcpListener> {
+        let sock = match *addr {
+            SocketAddr::V4(..) => TcpBuilder::new_v4(),
+            SocketAddr::V6(..) => TcpBuilder::new_v6(),
+        }?;
+
+        sock.reuse_address(true)?;
+        sock.bind(addr)?;
+        let listener = sock.listen(1024)?;
+        TcpListener::new(listener, handle)
+    }
+
+    pub fn new(listener: net::TcpListener, handle: &Handle) -> io::Result<TcpListener> {
+        set_nonblock(listener.as_raw_fd())?;
+
+        unsafe {
+            Ok(TcpListener(EventedFd::new(listener, handle.remote())?))
+       }
+    }
+
+    pub fn accept(&mut self) -> io::Result<(TcpStream, SocketAddr)> {
+        if let Async::NotReady = self.0.poll_read() {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+
+        match self.0.get_ref().accept() {
+            Err(e) => {
+                if e.kind() == io::ErrorKind::WouldBlock {
+                    self.0.need_read();
+                }
+                return Err(e)
+            },
+            Ok((sock, addr)) => {
+                return TcpStream::from_stream_remote(sock, self.remote())
+                    .map(|sock| (sock, addr))
+            }
+        }
+    }
+
+    pub fn from_listener(listener: net::TcpListener,
+                         _addr: &SocketAddr,
+                         handle: &Handle) -> io::Result<TcpListener> {
+        TcpListener::new(listener, handle)
+    }
+}
+
+pub(crate) struct TcpStream(EventedFd<net::TcpStream>);
+
+impl Deref for TcpStream {
+    type Target = EventedFd<net::TcpStream>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl TcpStream {
+    pub fn connect(addr: &SocketAddr, handle: &Handle) -> io::Result<TcpStream> {
+        let sock = match *addr {
+            SocketAddr::V4(..) => TcpBuilder::new_v4(),
+            SocketAddr::V6(..) => TcpBuilder::new_v6(),
+        }?;
+
+        TcpStream::connect_stream(sock.to_tcp_stream()?, addr, handle)
+    }
+
+    pub fn from_stream_remote(stream: net::TcpStream, remote: &Remote)
+        -> io::Result<TcpStream>
+    {
+        set_nonblock(stream.as_raw_fd())?;
+
+        let stream = unsafe { EventedFd::new(stream, remote)? } ;
+
+        Ok(TcpStream(stream))
+    }
+
+    pub fn from_stream(stream: net::TcpStream, handle: &Handle)
+        -> io::Result<TcpStream>
+    {
+        TcpStream::from_stream_remote(stream, handle.remote())
+    }
+
+    pub fn connect_stream(stream: net::TcpStream,
+                          addr: &SocketAddr,
+                          handle: &Handle) -> io::Result<TcpStream> {
+        set_nonblock(stream.as_raw_fd())?;
+
+        let connected = stream.connect(addr);
+        match connected {
+            Ok(..) => {}
+            Err(ref e) if e.raw_os_error() == Some(libc::EINPROGRESS) => {}
+            Err(e) => return Err(e),
+        }
+
+        let stream = unsafe { EventedFd::new(stream, handle.remote())? } ;
+
+        Ok(TcpStream(stream))
+    }
+
+    pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+        (&self.0).read(buf)
+    }
+
+    pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
+        (&self.0).write(buf)
+    }
+
+    pub fn read_buf<B: BufMut>(&self, buf: &mut B) -> Poll<usize, io::Error> {
+        match (&self.0).read(unsafe { buf.bytes_mut() }) {
+            Ok(n) => {
+                unsafe { buf.advance_mut(n); }
+                Ok(Async::Ready(n))
+            }
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.0.need_read();
+                Ok(Async::NotReady)
+            }
+            Err(e) => Err(e)
+        }
+    }
+
+    pub fn write_buf<B: Buf>(&self, buf: &mut B) -> Poll<usize, io::Error> {
+        match (&self.0).write(buf.bytes()) {
+            Ok(n) => {
+                buf.advance(n);
+                Ok(Async::Ready(n))
+            }
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.0.need_write();
+                Ok(Async::NotReady)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/src/net/fuchsia/udp.rs
+++ b/src/net/fuchsia/udp.rs
@@ -1,0 +1,37 @@
+use std::io;
+use std::net::{self, SocketAddr};
+use std::ops::Deref;
+
+use reactor::Handle;
+use net::fuchsia::{recv_from, set_nonblock, EventedFd};
+use std::os::unix::io::AsRawFd;
+
+/// An I/O object representing a UDP socket.
+pub(crate) struct UdpSocket(EventedFd<net::UdpSocket>);
+
+impl Deref for UdpSocket {
+    type Target = EventedFd<net::UdpSocket>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl UdpSocket {
+    pub fn bind(addr: &SocketAddr, handle: &Handle) -> io::Result<UdpSocket> {
+        let socket = net::UdpSocket::bind(addr)?;
+        UdpSocket::from_socket(socket, handle)
+    }
+
+    pub fn from_socket(socket: net::UdpSocket, handle: &Handle) -> io::Result<UdpSocket> {
+        set_nonblock(socket.as_raw_fd())?;
+
+        unsafe {
+            Ok(UdpSocket(EventedFd::new(socket, handle.remote())?))
+       }
+    }
+
+    pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        unsafe { recv_from(self.0.as_raw_fd(), buf) }
+    }
+}

--- a/src/net/mio/mod.rs
+++ b/src/net/mio/mod.rs
@@ -1,0 +1,5 @@
+pub mod tcp;
+pub use self::tcp::{TcpListener, TcpStream};
+
+pub mod udp;
+pub use self::udp::UdpSocket;

--- a/src/net/mio/tcp.rs
+++ b/src/net/mio/tcp.rs
@@ -1,0 +1,207 @@
+use std::io;
+use std::net::{self, SocketAddr};
+use std::ops::{Deref, DerefMut};
+
+use bytes::{Buf, BufMut};
+use futures::sync::oneshot;
+use futures::{Future, Poll, Async};
+use iovec::IoVec;
+use mio;
+
+use reactor::{Handle, PollEvented};
+
+pub struct TcpListener {
+    io: PollEvented<mio::net::TcpListener>,
+    pending_accept: Option<oneshot::Receiver<io::Result<(TcpStream, SocketAddr)>>>,
+}
+
+impl Deref for TcpListener {
+    type Target = PollEvented<mio::net::TcpListener>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.io
+    }
+}
+
+impl TcpListener {
+    pub fn bind(addr: &SocketAddr, handle: &Handle) -> io::Result<TcpListener> {
+        let l = try!(mio::net::TcpListener::bind(addr));
+        TcpListener::new(l, handle)
+    }
+
+    fn new(listener: mio::net::TcpListener, handle: &Handle)
+           -> io::Result<TcpListener> {
+        Ok(TcpListener {
+            io: PollEvented::new(listener, handle)?,
+            pending_accept: None,
+        })
+    } 
+
+    pub fn from_listener(listener: net::TcpListener, addr: &SocketAddr, handle: &Handle) ->
+        io::Result<TcpListener>
+    {
+        TcpListener::new(mio::net::TcpListener::from_listener(listener, addr)?, handle)
+    }
+
+    pub fn accept(&mut self) -> io::Result<(TcpStream, SocketAddr)> {
+        loop {
+            if let Some(mut pending) = self.pending_accept.take() {
+                match pending.poll().expect("shouldn't be canceled") {
+                    Async::NotReady => {
+                        self.pending_accept = Some(pending);
+                        return Err(io::ErrorKind::WouldBlock.into())
+                    },
+                    Async::Ready(r) => return r,
+                }
+            }
+
+            if let Async::NotReady = self.io.poll_read() {
+                return Err(io::Error::new(io::ErrorKind::WouldBlock, "not ready"))
+            }
+
+            match self.io.get_ref().accept() {
+                Err(e) => {
+                    if e.kind() == io::ErrorKind::WouldBlock {
+                        self.io.need_read();
+                    }
+                    return Err(e)
+                },
+                Ok((sock, addr)) => {
+                    // Fast path if we haven't left the event loop
+                    if let Some(handle) = self.io.remote().handle() {
+                        return PollEvented::new(sock, &handle)
+                           .map(|sock| (TcpStream(sock), addr));
+                    }
+
+                    // If we're off the event loop then send the socket back
+                    // over there to get registered and then we'll get it back
+                    // eventually.
+                    let (tx, rx) = oneshot::channel();
+                    let remote = self.io.remote().clone();
+                    remote.spawn(move |handle| {
+                        let res = PollEvented::new(sock, handle)
+                            .map(move |io| {
+                                (TcpStream(io), addr)
+                            });
+                        drop(tx.send(res));
+                        Ok(())
+                    });
+                    self.pending_accept = Some(rx);
+                    // continue to polling the `rx` at the beginning of the loop
+                }
+            }
+        }
+    }
+}
+
+pub struct TcpStream(PollEvented<mio::net::TcpStream>);
+
+impl Deref for TcpStream {
+    type Target = PollEvented<mio::net::TcpStream>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for TcpStream {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl TcpStream {
+    pub fn connect(addr: &SocketAddr, handle: &Handle) -> io::Result<TcpStream> {
+        Ok(TcpStream(PollEvented::new(mio::net::TcpStream::connect(addr)?, handle)?))
+    }
+
+    pub fn connect_stream(stream: net::TcpStream, addr: &SocketAddr, handle: &Handle)
+        -> Result<TcpStream, io::Error>
+    {
+        Ok(TcpStream(PollEvented::new(mio::net::TcpStream::connect_stream(stream, addr)?, handle)?))
+    }
+
+    pub fn from_stream(stream: net::TcpStream, handle: &Handle) -> io::Result<TcpStream> {
+        Ok(TcpStream(PollEvented::new(mio::net::TcpStream::from_stream(stream)?, handle)?))
+    }
+
+    pub fn read_buf<B: BufMut>(&self, buf: &mut B) -> Poll<usize, io::Error> {
+        if let Async::NotReady = self.poll_read() {
+            return Ok(Async::NotReady)
+        }
+        let r = unsafe {
+            // The `IoVec` type can't have a 0-length size, so we create a bunch
+            // of dummy versions on the stack with 1 length which we'll quickly
+            // overwrite.
+            let b1: &mut [u8] = &mut [0];
+            let b2: &mut [u8] = &mut [0];
+            let b3: &mut [u8] = &mut [0];
+            let b4: &mut [u8] = &mut [0];
+            let b5: &mut [u8] = &mut [0];
+            let b6: &mut [u8] = &mut [0];
+            let b7: &mut [u8] = &mut [0];
+            let b8: &mut [u8] = &mut [0];
+            let b9: &mut [u8] = &mut [0];
+            let b10: &mut [u8] = &mut [0];
+            let b11: &mut [u8] = &mut [0];
+            let b12: &mut [u8] = &mut [0];
+            let b13: &mut [u8] = &mut [0];
+            let b14: &mut [u8] = &mut [0];
+            let b15: &mut [u8] = &mut [0];
+            let b16: &mut [u8] = &mut [0];
+            let mut bufs: [&mut IoVec; 16] = [
+                b1.into(), b2.into(), b3.into(), b4.into(),
+                b5.into(), b6.into(), b7.into(), b8.into(),
+                b9.into(), b10.into(), b11.into(), b12.into(),
+                b13.into(), b14.into(), b15.into(), b16.into(),
+            ];
+            let n = buf.bytes_vec_mut(&mut bufs);
+            self.get_ref().read_bufs(&mut bufs[..n])
+        };
+
+        match r {
+            Ok(n) => {
+                unsafe { buf.advance_mut(n); }
+                Ok(Async::Ready(n))
+            }
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.need_read();
+                Ok(Async::NotReady)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn write_buf<B: Buf>(&self, buf: &mut B) -> Poll<usize, io::Error> {
+        if let Async::NotReady = self.poll_write() {
+            return Ok(Async::NotReady)
+        }
+        let r = {
+            // The `IoVec` type can't have a zero-length size, so create a dummy
+            // version from a 1-length slice which we'll overwrite with the
+            // `bytes_vec` method.
+            static DUMMY: &[u8] = &[0];
+            let iovec = <&IoVec>::from(DUMMY);
+            let mut bufs = [
+                iovec, iovec, iovec, iovec,
+                iovec, iovec, iovec, iovec,
+                iovec, iovec, iovec, iovec,
+                iovec, iovec, iovec, iovec,
+            ];
+            let n = buf.bytes_vec(&mut bufs);
+            self.0.get_ref().write_bufs(&bufs[..n])
+        };
+        match r {
+            Ok(n) => {
+                buf.advance(n);
+                Ok(Async::Ready(n))
+            }
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.0.need_write();
+                Ok(Async::NotReady)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+

--- a/src/net/mio/udp.rs
+++ b/src/net/mio/udp.rs
@@ -1,0 +1,47 @@
+use std::io;
+use std::net::{self, SocketAddr};
+use std::fmt;
+use std::ops::Deref;
+
+use mio;
+
+use reactor::{Handle, PollEvented};
+
+/// An I/O object representing a UDP socket.
+pub struct UdpSocket(PollEvented<mio::net::UdpSocket>);
+
+impl Deref for UdpSocket {
+    type Target = PollEvented<mio::net::UdpSocket>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl UdpSocket {
+    pub fn bind(addr: &SocketAddr, handle: &Handle) -> io::Result<UdpSocket> {
+        let udp = try!(mio::net::UdpSocket::bind(addr));
+        UdpSocket::new(udp, handle)
+    }
+
+    fn new(socket: mio::net::UdpSocket, handle: &Handle) -> io::Result<UdpSocket> {
+        let io = try!(PollEvented::new(socket, handle));
+        Ok(UdpSocket(io))
+    }
+
+    pub fn from_socket(socket: net::UdpSocket,
+                       handle: &Handle) -> io::Result<UdpSocket> {
+        let udp = try!(mio::net::UdpSocket::from_socket(socket));
+        UdpSocket::new(udp, handle)
+    }
+
+    pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        self.get_ref().recv_from(buf)
+    }
+}
+
+impl fmt::Debug for UdpSocket {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.get_ref().fmt(f)
+    }
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -3,9 +3,21 @@
 //! This module contains the TCP/UDP networking types, similar to the standard
 //! library, which can be used to implement networking protocols.
 
+//#![allow(warnings)]
+
 mod tcp;
 mod udp;
 
 pub use self::tcp::{TcpStream, TcpStreamNew};
 pub use self::tcp::{TcpListener, Incoming};
 pub use self::udp::{UdpSocket, UdpCodec, UdpFramed, SendDgram, RecvDgram};
+
+#[cfg(not(target_os = "fuchsia"))]
+mod mio;
+#[cfg(not(target_os = "fuchsia"))]
+use self::mio as sys;
+
+#[cfg(target_os = "fuchsia")]
+mod fuchsia;
+#[cfg(target_os = "fuchsia")]
+use self::fuchsia as sys;

--- a/src/reactor/fuchsia/interval.rs
+++ b/src/reactor/fuchsia/interval.rs
@@ -1,0 +1,34 @@
+use std::io;
+use std::time::{Duration, Instant};
+
+use reactor;
+use reactor::interval::next_interval;
+use reactor::sys::Timeout;
+use futures::{Poll, Async};
+
+pub(crate) struct Interval {
+    timeout: Timeout,
+    duration: Duration,
+}
+
+impl Interval {
+    pub fn new_at(at: Instant, dur: Duration, handle: &reactor::Handle)
+        -> io::Result<Interval>
+    {
+        Ok(Interval {
+            timeout: Timeout::new_at(at, handle)?,
+            duration: dur,
+        })
+    }
+
+    pub fn poll_at(&mut self, now: Instant) -> Poll<Option<()>, io::Error> {
+        Ok(match self.timeout.poll_at(now)? {
+            Async::Ready(()) => {
+                let next_timeout = next_interval(self.timeout.next(), now, self.duration);
+                self.timeout.reset(next_timeout);
+                Async::Ready(Some(()))
+            },
+            Async::NotReady => Async::NotReady,
+        })
+    }
+}

--- a/src/reactor/fuchsia/mod.rs
+++ b/src/reactor/fuchsia/mod.rs
@@ -1,0 +1,501 @@
+//! The core reactor driving all I/O
+//!
+//! This module contains the `Core` type which is the reactor for all I/O
+//! happening in `tokio-core`. This reactor (or event loop) is used to run
+//! futures, schedule tasks, issue I/O requests, etc.
+
+use std::cell::RefCell;
+use std::{fmt, mem, io};
+use std::rc::Rc;
+use std::sync::{Arc, RwLock};
+use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use std::time::Duration;
+
+use futures::{Future, IntoFuture, Async};
+use futures::future::{Executor, ExecuteError};
+use futures::executor::{self, Spawn, Notify};
+use futures::sync::mpsc;
+use slab::Slab;
+
+mod interval;
+mod timeout;
+
+pub(crate) use self::timeout::Timeout;
+pub(crate) use self::interval::Interval;
+
+use reactor::{self, CoreId, fuchsia};
+
+use zx;
+
+// Key set aside for the main task in `run`.
+const MAIN_TASK_KEY: usize = ::std::usize::MAX;
+
+// Key set aside for the `spawn_task_channel`.
+const SPAWN_TASK_KEY: usize = ::std::usize::MAX - 1;
+
+static NEXT_LOOP_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+scoped_thread_local!(static CURRENT_LOOP: Core);
+
+type UnitFuture = Box<Future<Item = (), Error = ()>>;
+
+trait SpawnFn: Send + 'static {
+    fn call_box(self: Box<Self>, handle: &reactor::Handle) -> UnitFuture;
+}
+
+impl<F> SpawnFn for F
+    where F: (FnOnce(&reactor::Handle) -> UnitFuture) + Send + 'static
+{
+    fn call_box(self: Box<Self>, handle: &reactor::Handle) -> UnitFuture {
+        (*self)(handle)
+    }
+}
+
+/// A port-based executor for Fuchsia.
+// NOTE: intentionally does not implement `Clone`.
+pub(crate) struct Core {
+    spawn_task_rx: Spawn<mpsc::UnboundedReceiver<Box<SpawnFn>>>,
+    handle: Handle,
+}
+
+impl Drop for Core {
+    fn drop(&mut self) {
+        // Remove all tasks in order to prevent a task a `Handle`
+        // from causing a reference cycle and keeping the `Slab`
+        // from dropping.
+        self.handle.tasks.borrow_mut().clear();
+    }
+}
+
+/// A handle to an event loop backed by a `Port`.
+#[derive(Clone)]
+pub(crate) struct Handle {
+    tasks: Rc<RefCell<Slab<Option<Spawn<UnitFuture>>>>>,
+    remote: reactor::Remote,
+}
+
+#[derive(Clone)]
+pub(crate) struct Remote {
+    io_inner: Arc<IoInner>
+}
+
+struct IoInner {
+    id: usize,
+    port: zx::Port,
+    packet_receivers: RwLock<Slab<Arc<PacketReceiver>>>,
+    spawn_task_tx: mpsc::UnboundedSender<Box<SpawnFn>>,
+}
+
+impl Notify for IoInner {
+    fn notify(&self, id: usize) {
+        let up = zx::UserPacket::from_u8_array([0; 32]);
+        let packet = zx::Packet::from_user_packet(id as u64, 0 /* status */, up);
+        self.port.queue(&packet).expect("Failed to queue notify in port");
+    }
+}
+
+// Implemented as a macro than a function to allow the compiler to observe that
+// the borrows of `io_inner`, `tasks`, and `spawn_task_rx` are disjoint.
+macro_rules! io_inner {
+    ($self:ident) => { &$self.handle.remote.sys.io_inner }
+}
+
+/// A trait for handling the arrival of a packet on a `zx::Port`.
+///
+/// This trait should be implemented by users who wish to write their own
+/// types which receive asynchronous notifications from a `zx::Port`.
+/// Implementors of this trait generally contain an `AtomicTask` which
+/// is used to wake up the task which can make progress due to the arrival of
+/// the packet.
+///
+/// `PacketReceiver`s should be registered with a `Core` using the
+/// `register_packet_receiver` method on `Core`, `Handle`, or `Remote`.
+/// Upon registration, users will receive a `ReceiverRegistration`
+/// which provides `key` and `port` methods which can be used to wait on
+/// asynchronous signals.
+pub trait PacketReceiver: Send + Sync + 'static {
+    /// Receive a packet when one arrives.
+    fn receive_packet(&self, packet: zx::Packet);
+}
+
+/// A registration of a `PacketReceiver`.
+/// When dropped, it will automatically deregister the `PacketReceiver`.
+// NOTE: purposefully does not implement `Clone`.
+#[derive(Debug)]
+pub struct ReceiverRegistration<T: PacketReceiver> {
+    receiver: Arc<T>,
+    remote: reactor::Remote,
+    key: usize,
+}
+
+impl<T> ReceiverRegistration<T> where T: PacketReceiver {
+    /// The key with which `Packet`s destined for this receiver should be sent on the `Port`.
+    pub fn key(&self) -> u64 {
+        self.key as u64
+    }
+
+    /// The internal `PacketReceiver`.
+    pub fn receiver(&self) -> &T {
+        &*self.receiver
+    }
+
+    /// The `Remote` with which the `PacketReceiver` is registered.
+    pub fn remote(&self) -> &reactor::Remote {
+        &self.remote
+    }
+
+    /// The `Port` on which packets destined for this `PacketReceiver` should be queued.
+    pub fn port(&self) -> &zx::Port {
+        self.remote.port()
+    }
+}
+
+impl<T> Drop for ReceiverRegistration<T> where T: PacketReceiver {
+    fn drop(&mut self) {
+        self.remote.sys.deregister_packet_receiver(self.key);
+    }
+}
+
+impl Core {
+    pub fn new() -> io::Result<Core> {
+        let (spawn_task_tx, spawn_task_rx) = mpsc::unbounded();
+        let spawn_task_rx = executor::spawn(spawn_task_rx);
+
+        let io_inner = Arc::new(IoInner {
+            id: NEXT_LOOP_ID.fetch_add(1, Ordering::Relaxed),
+            port: zx::Port::create()?,
+            packet_receivers: RwLock::new(Slab::new()),
+            spawn_task_tx,
+        });
+
+        // Start out with spawn_task_rx notified so that it will be polled once
+        io_inner.notify(SPAWN_TASK_KEY);
+
+        Ok(Core {
+            spawn_task_rx,
+            handle: Handle {
+                tasks: Rc::new(RefCell::new(Slab::new())),
+                remote: reactor::Remote { sys: Remote { io_inner } },
+            },
+        })
+    }
+
+    pub fn port(&self) -> &zx::Port {
+        self.handle.port()
+    }
+
+    pub fn register_packet_receiver<T>(&self, packet_receiver: Arc<T>) -> ReceiverRegistration<T>
+        where T: fuchsia::PacketReceiver
+    {
+        self.handle.register_packet_receiver(packet_receiver)
+    }
+
+    pub fn handle(&self) -> Handle {
+        self.handle.clone()
+    }
+
+    pub fn remote(&self) -> Remote {
+        self.handle.remote.sys.clone()
+    }
+
+    pub fn run<F>(&mut self, f: F) -> Result<F::Item, F::Error>
+        where F: Future,
+    {
+        let mut task = executor::spawn(f);
+        let mut future_fired = true;
+
+        loop {
+            if future_fired {
+                let res = CURRENT_LOOP.set(self, || {
+                   task.poll_future_notify(io_inner!(self), MAIN_TASK_KEY)
+                })?;
+                if let Async::Ready(e) = res {
+                    return Ok(e);
+                }
+            }
+            future_fired = self.poll(None);
+        }
+    }
+
+    /// Performs one iteration of the event loop, blocking on waiting for events
+    /// for at most `max_wait` (forever if `None`).
+    ///
+    /// It only makes sense to call this method if you've previously spawned
+    /// a future onto this event loop.
+    ///
+    /// `loop { lp.turn(None) }` is equivalent to calling `run` with an
+    /// empty future (one that never finishes).
+    pub fn turn(&mut self, max_wait: Option<Duration>) {
+        self.poll(max_wait);
+    }
+
+    fn poll(&mut self, max_wait: Option<Duration>) -> bool {
+        let deadline = match max_wait {
+            Some(duration) => {
+                let duration = zx::Duration::from_seconds(duration.as_secs()) +
+                               zx::Duration::from_nanos(duration.subsec_nanos() as u64);
+                zx::Time::after(duration)
+            },
+            None => zx::Time::INFINITE,
+        };
+        let packet = match self.port().wait(deadline) {
+            Ok(p) => p,
+            Err(zx::Status::TIMED_OUT) |
+            Err(zx::Status::INTERRUPTED_RETRY) => return false,
+            Err(e) => panic!("Error polling tokio_core::reactor::Core's port: {:?}", e),
+        };
+
+        // This cast is a no-op because Fuchsia only supports 64-bit platforms.
+        let notify_key = packet.key() as usize;
+
+        if notify_key == MAIN_TASK_KEY {
+            return true;
+        }
+
+        if notify_key == SPAWN_TASK_KEY {
+            // Spawn all available tasks
+            loop {
+                let task_async = self.spawn_task_rx.poll_stream_notify(
+                                    io_inner!(self), SPAWN_TASK_KEY).unwrap();
+
+                match task_async {
+                    Async::Ready(Some(task_fn)) => {
+                        let handle = reactor::Handle { sys: self.handle.clone() };
+                        let box_future = task_fn.call_box(&handle);
+                        let key = self.handle.tasks.borrow_mut()
+                                      .insert(Some(executor::spawn(box_future)));
+                        io_inner!(self).notify(key);
+                    },
+                    Async::NotReady |
+                    Async::Ready(None) => return false,
+                }
+            }
+        }
+
+		let (key, key_kind) = notify_key_to_key(notify_key);
+		match key_kind {
+			KeyKind::Task => {
+                self.dispatch_task(key);
+			}
+            KeyKind::Receiver => {
+                let lock = self.handle.remote.sys.io_inner.packet_receivers.read()
+                               .expect("tokio_core packet_receivers poisoned");
+
+                if let Some(packet_receiver) = lock.get(key) {
+                    packet_receiver.receive_packet(packet);
+                }
+            }
+		}
+
+        false
+    }
+
+    fn dispatch_task(&self, key: usize) {
+        let mut task = {
+            let mut mut_tasks = self.handle.tasks.borrow_mut();
+            if let Some(task) = mut_tasks.get_mut(key).and_then(|ref mut t| t.take()) {
+                task
+            } else {
+                return
+            }
+        };
+
+        let is_finished = match task.poll_future_notify(io_inner!(self), key) {
+            Ok(Async::NotReady) => false,
+            Ok(Async::Ready(())) | Err(()) => true,
+        };
+
+        let mut mut_tasks = self.handle.tasks.borrow_mut();
+        if is_finished {
+            mut_tasks.remove(key);
+        } else {
+            mut_tasks[key] = Some(task);
+        }
+    }
+
+    /// Get the ID of this loop
+    pub fn id(&self) -> CoreId {
+        self.handle.id()
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+enum KeyKind {
+    Task,
+    Receiver,
+}
+
+#[inline(always)]
+fn usize_high_bit() -> usize {
+    1usize << (::std::usize::MAX.count_ones() - 1)
+}
+
+fn notify_key_to_key(notify_key: usize) -> (usize, KeyKind) {
+    (
+        notify_key & !usize_high_bit(),
+        match notify_key & usize_high_bit() {
+            0 => KeyKind::Task,
+            _ => KeyKind::Receiver,
+        }
+    )
+}
+
+fn key_to_notify_key(key: usize, kind: KeyKind) -> usize {
+    if key & usize_high_bit() != 0 {
+        panic!("ID flowed into usize top bit");
+    }
+    key | match kind {
+        KeyKind::Task => 0,
+        KeyKind::Receiver => usize_high_bit(),
+    }
+}
+
+impl<F> Executor<F> for Core
+    where F: Future<Item = (), Error = ()> + 'static,
+{
+    fn execute(&self, future: F) -> Result<(), ExecuteError<F>> {
+        self.handle.spawn(future);
+        Ok(())
+    }
+}
+
+impl Remote {
+    // Returns a reference to the underlying Zircon `Port` through which packet
+    // notifications are scheduled.
+    pub fn port(&self) -> &zx::Port {
+        &self.io_inner.port
+    }
+
+    pub fn register_packet_receiver<T>(&self, packet_receiver: Arc<T>) -> ReceiverRegistration<T>
+        where T: fuchsia::PacketReceiver
+    {
+        let key = self.io_inner.packet_receivers
+                      .write().expect("tokio_core packet recievers were poisoned")
+                      .insert(packet_receiver.clone());
+
+        let notify_key = key_to_notify_key(key, KeyKind::Receiver);
+
+        ReceiverRegistration {
+            remote: reactor::Remote { sys: self.clone() },
+            key: notify_key,
+            receiver: packet_receiver,
+        }
+    }
+
+    fn deregister_packet_receiver(&self, key: usize) {
+        let (key, key_kind) = notify_key_to_key(key);
+        if let KeyKind::Task = key_kind {
+            error!("Attempted to deregister packet receiver with task key");
+            return;
+        }
+
+        self.io_inner.packet_receivers
+            .write().expect("tokio_core packet receivers were poisoned")
+            .remove(key);
+    }
+
+
+    pub fn spawn<F, R>(&self, f: F)
+        where F: FnOnce(&reactor::Handle) -> R + Send + 'static,
+              R: IntoFuture<Item=(), Error=()>,
+              R::Future: 'static,
+    {
+        match self.io_inner.spawn_task_tx.unbounded_send(Box::new(|h: &_| {
+            Box::new(f(h).into_future()) as UnitFuture
+        })) {
+            Ok(()) => {},
+            Err(e) => mem::drop(e), // see tokio-core#17-- error should bubble
+        }
+    }
+
+    /// Return the ID of the represented Core
+    pub fn id(&self) -> CoreId {
+        CoreId(self.io_inner.id)
+    }
+
+    /// Attempts to "promote" this remote to a handle, if possible.
+    ///
+    /// This function is intended for structures which typically work through a
+    /// `Remote` but want to optimize runtime when the remote doesn't actually
+    /// leave the thread of the original reactor.
+    /// 
+    /// However, on Fuchsia, `Handle` and `Remote` have the same representation
+    /// so we can just `clone` the original type.
+    pub fn handle(&self) -> Option<Handle> {
+        if CURRENT_LOOP.is_set() {
+            CURRENT_LOOP.with(|lp| {
+                let same = lp.id() == self.id();
+                if same {
+                    Some(lp.handle())
+                } else {
+                    None
+                }
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Debug for Remote {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Remote")
+         .field("id", &self.id())
+         .finish()
+    }
+}
+
+impl Handle {
+    // Returns a reference to the underlying Zircon `Port` through which packet
+    // notifications are be scheduled.
+    pub fn port(&self) -> &zx::Port {
+        self.remote.port()
+    }
+
+    pub fn register_packet_receiver<T>(&self, packet_receiver: Arc<T>) -> ReceiverRegistration<T>
+        where T: fuchsia::PacketReceiver
+    {
+        self.remote.register_packet_receiver(packet_receiver)
+    }
+
+    /// Returns a reference to the underlying remote handle to the event loop.
+    pub fn remote(&self) -> &reactor::Remote {
+        &self.remote
+    }
+
+    /// Spawns a new future on the event loop this handle is associated with.
+    pub fn spawn<F>(&self, f: F)
+        where F: Future<Item=(), Error=()> + 'static,
+    {
+        let key = self.tasks.borrow_mut()
+                      .insert(Some(executor::spawn(Box::new(f))));
+        self.remote.sys.io_inner.notify(key);
+    }
+
+    /// Return the ID of the represented Core
+    pub fn id(&self) -> CoreId {
+        self.remote.id()
+    }
+}
+
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Handle")
+         .field("id", &self.id())
+         .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn id_token_can_store_kind() {
+        for id in 0..1000 {
+            for &kind in [KeyKind::Task, KeyKind::Receiver].iter() {
+                let notify_id = key_to_notify_key(id, kind);
+                let (out_id, out_kind) = notify_key_to_key(notify_id);
+                assert_eq!((id, kind), (out_id, out_kind));
+            }
+        }
+	}
+}

--- a/src/reactor/fuchsia/timeout.rs
+++ b/src/reactor/fuchsia/timeout.rs
@@ -1,0 +1,94 @@
+//! Support for creating futures that represent timeouts.
+//!
+//! This module contains the `Timeout` type which is a future that will resolve
+//! at a particular point in the future.
+
+use std::io;
+use std::time::{Duration, Instant};
+use std::sync::Arc;
+
+use futures::{Poll, Async};
+use futures::task::AtomicTask;
+
+use reactor::{self, ReceiverRegistration, PacketReceiver};
+
+use zx;
+use zx::prelude::*;
+
+#[derive(Debug)]
+pub(crate) struct TimeoutReceiver(AtomicTask);
+
+impl PacketReceiver for TimeoutReceiver {
+    fn receive_packet(&self, packet: zx::Packet) {
+        if let zx::PacketContents::SignalRep(signals) = packet.contents() {
+            if signals.observed().contains(zx::Signals::TIMER_SIGNALED) {
+                self.0.notify();
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Timeout {
+    timer: zx::Timer,
+    instant: Instant,
+    timeout_receiver: ReceiverRegistration<TimeoutReceiver>,
+}
+
+impl Timeout {
+    pub fn new_at(instant: Instant, handle: &reactor::Handle) -> io::Result<Timeout> {
+        let zx_dur = duration_until_instant(instant);
+
+        let timeout_receiver = handle.register_packet_receiver(
+            Arc::new(TimeoutReceiver(AtomicTask::new()))
+        );
+
+        let timer = zx::Timer::create(zx::ClockId::Monotonic)?;
+
+        timer.wait_async_handle(
+            handle.port(),
+            timeout_receiver.key(),
+            zx::Signals::TIMER_SIGNALED,
+            zx::WaitAsyncOpts::Repeating
+        )?;
+
+        timer.set(zx_dur.after_now(), 0.nanos())?;
+
+        Ok(Timeout {
+            timer,
+            instant,
+            timeout_receiver,
+        })
+    }
+
+    pub fn next(&self) -> Instant {
+        self.instant
+    }
+
+    pub fn reset(&mut self, at: Instant) {
+        self.instant = at;
+        if let Err(e) = self.timer.set(duration_until_instant(at).after_now(), 0.nanos()) {
+            error!("tokio_core error setting timer: {:?}", e);
+        }
+    }
+
+    pub fn poll_at(&mut self, now: Instant) -> Poll<(), io::Error> {
+        if self.instant <= now {
+            Ok(Async::Ready(()))
+        } else {
+            self.timeout_receiver.receiver().0.register();
+            Ok(Async::NotReady)
+        }
+    }
+}
+
+fn duration_until_instant(at: Instant) -> zx::Duration {
+    let start = Instant::now();
+    let dur = if at < start {
+        Duration::new(0, 0)
+    } else {
+        at - start
+    };
+
+    zx::Duration::from(dur)
+}

--- a/src/reactor/mio/interval.rs
+++ b/src/reactor/mio/interval.rs
@@ -1,0 +1,117 @@
+use std::io;
+use std::time::{Duration, Instant};
+
+use futures::{Poll, Async};
+
+use reactor;
+use reactor::mio::Remote;
+use reactor::mio::timeout_token::TimeoutToken;
+use reactor::interval::next_interval;
+
+pub struct Interval {
+    token: TimeoutToken,
+    next: Instant,
+    interval: Duration,
+    handle: Remote,
+}
+
+impl Interval {
+    pub fn new_at(at: Instant, dur: Duration, handle: &reactor::Handle)
+        -> io::Result<Interval>
+    {
+        Ok(Interval {
+            token: try!(TimeoutToken::new(at, handle.as_sys())),
+            next: at,
+            interval: dur,
+            handle: handle.remote().clone().into_sys(),
+        })
+    }
+
+    pub fn poll_at(&mut self, now: Instant) -> Poll<Option<()>, io::Error> {
+        if self.next <= now {
+            self.next = next_interval(self.next, now, self.interval);
+            self.token.reset_timeout(self.next, &self.handle);
+            Ok(Async::Ready(Some(())))
+        } else {
+            self.token.update_timeout(&self.handle);
+            Ok(Async::NotReady)
+        }
+    }
+}
+
+impl Drop for Interval {
+    fn drop(&mut self) {
+        self.token.cancel_timeout(&self.handle);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::time::{Instant, Duration};
+    use super::next_interval;
+
+    struct Timeline(Instant);
+
+    impl Timeline {
+        fn new() -> Timeline {
+            Timeline(Instant::now())
+        }
+        fn at(&self, millis: u64) -> Instant {
+            self.0 + Duration::from_millis(millis)
+        }
+        fn at_ns(&self, sec: u64, nanos: u32) -> Instant {
+            self.0 + Duration::new(sec, nanos)
+        }
+    }
+
+    fn dur(millis: u64) -> Duration {
+        Duration::from_millis(millis)
+    }
+
+    // The math around Instant/Duration isn't 100% precise due to rounding
+    // errors, see #249 for more info
+    fn almost_eq(a: Instant, b: Instant) -> bool {
+        if a == b {
+            true
+        } else if a > b {
+            a - b < Duration::from_millis(1)
+        } else {
+            b - a < Duration::from_millis(1)
+        }
+    }
+
+    #[test]
+    fn norm_next() {
+        let tm = Timeline::new();
+        assert!(almost_eq(next_interval(tm.at(1), tm.at(2), dur(10)),
+                                        tm.at(11)));
+        assert!(almost_eq(next_interval(tm.at(7777), tm.at(7788), dur(100)),
+                                        tm.at(7877)));
+        assert!(almost_eq(next_interval(tm.at(1), tm.at(1000), dur(2100)),
+                                        tm.at(2101)));
+    }
+
+    #[test]
+    fn fast_forward() {
+        let tm = Timeline::new();
+        assert!(almost_eq(next_interval(tm.at(1), tm.at(1000), dur(10)),
+                                        tm.at(1001)));
+        assert!(almost_eq(next_interval(tm.at(7777), tm.at(8888), dur(100)),
+                                        tm.at(8977)));
+        assert!(almost_eq(next_interval(tm.at(1), tm.at(10000), dur(2100)),
+                                        tm.at(10501)));
+    }
+
+    /// TODO: this test actually should be successful, but since we can't
+    ///       multiply Duration on anything larger than u32 easily we decided
+    ///       to allow it to fail for now
+    #[test]
+    #[should_panic(expected = "can't skip more than 4 billion intervals")]
+    fn large_skip() {
+        let tm = Timeline::new();
+        assert_eq!(next_interval(
+            tm.at_ns(0, 1), tm.at_ns(25, 0), Duration::new(0, 2)),
+            tm.at_ns(25, 1));
+    }
+
+}

--- a/src/reactor/mio/io_token.rs
+++ b/src/reactor/mio/io_token.rs
@@ -5,7 +5,7 @@ use std::io;
 use futures::task;
 use mio::event::Evented;
 
-use reactor::{Message, Remote, Handle, Direction};
+use reactor::mio::{Message, Remote, Handle, Direction};
 
 /// A token that identifies an active timeout.
 pub struct IoToken {

--- a/src/reactor/mio/mod.rs
+++ b/src/reactor/mio/mod.rs
@@ -1,0 +1,884 @@
+//! The core reactor driving all I/O
+//!
+//! This module contains the `Core` type which is the reactor for all I/O
+//! happening in `tokio-core`. This reactor (or event loop) is used to run
+//! futures, schedule tasks, issue I/O requests, etc.
+
+use std::cell::RefCell;
+use std::cmp;
+use std::fmt;
+use std::io::{self, ErrorKind};
+use std::mem;
+use std::rc::{Rc, Weak};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use std::time::{Instant, Duration};
+
+use futures::{Future, IntoFuture, Async};
+use futures::future::{Executor, ExecuteError};
+use futures::executor::{self, Spawn, Notify};
+use futures::sync::mpsc;
+use futures::task::Task;
+use mio;
+use mio::event::Evented;
+use slab::Slab;
+
+use heap::{Heap, Slot};
+
+mod interval;
+mod io_token;
+mod poll_evented;
+mod timeout;
+mod timeout_token;
+
+pub use self::poll_evented::PollEvented;
+pub use self::timeout::Timeout;
+pub use self::interval::Interval;
+
+use reactor::{self, CoreId};
+
+static NEXT_LOOP_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+scoped_thread_local!(static CURRENT_LOOP: Core);
+
+/// An event loop.
+///
+/// The event loop is the main source of blocking in an application which drives
+/// all other I/O events and notifications happening. Each event loop can have
+/// multiple handles pointing to it, each of which can then be used to create
+/// various I/O objects to interact with the event loop in interesting ways.
+// TODO: expand this
+pub struct Core {
+    events: mio::Events,
+    tx: mpsc::UnboundedSender<Message>,
+    rx: RefCell<Spawn<mpsc::UnboundedReceiver<Message>>>,
+    _rx_registration: mio::Registration,
+    rx_readiness: Arc<MySetReadiness>,
+
+    inner: Rc<RefCell<Inner>>,
+
+    // Used for determining when the future passed to `run` is ready. Once the
+    // registration is passed to `io` above we never touch it again, just keep
+    // it alive.
+    _future_registration: mio::Registration,
+    future_readiness: Arc<MySetReadiness>,
+}
+
+struct Inner {
+    id: usize,
+    io: mio::Poll,
+
+    // Dispatch slabs for I/O and futures events
+    io_dispatch: Slab<ScheduledIo>,
+    task_dispatch: Slab<ScheduledTask>,
+
+    // Timer wheel keeping track of all timeouts. The `usize` stored in the
+    // timer wheel is an index into the slab below.
+    //
+    // The slab below keeps track of the timeouts themselves as well as the
+    // state of the timeout itself. The `TimeoutToken` type is an index into the
+    // `timeouts` slab.
+    timer_heap: Heap<(Instant, usize)>,
+    timeouts: Slab<(Option<Slot>, TimeoutState)>,
+}
+
+/// Handle to an event loop, used to construct I/O objects, send messages, and
+/// otherwise interact indirectly with the event loop itself.
+///
+/// Handles can be cloned, and when cloned they will still refer to the
+/// same underlying event loop.
+#[derive(Clone)]
+pub struct Remote {
+    id: usize,
+    tx: mpsc::UnboundedSender<Message>,
+}
+
+/// A non-sendable handle to an event loop, useful for manufacturing instances
+/// of `LoopData`.
+#[derive(Clone)]
+pub struct Handle {
+    remote: reactor::Remote,
+    inner: Weak<RefCell<Inner>>,
+}
+
+struct ScheduledIo {
+    readiness: Arc<AtomicUsize>,
+    reader: Option<Task>,
+    writer: Option<Task>,
+}
+
+struct ScheduledTask {
+    _registration: mio::Registration,
+    spawn: Option<Spawn<Box<Future<Item=(), Error=()>>>>,
+    wake: Option<Arc<MySetReadiness>>,
+}
+
+enum TimeoutState {
+    NotFired,
+    Fired,
+    Waiting(Task),
+}
+
+enum Direction {
+    Read,
+    Write,
+}
+
+enum Message {
+    DropSource(usize),
+    Schedule(usize, Task, Direction),
+    UpdateTimeout(usize, Task),
+    ResetTimeout(usize, Instant),
+    CancelTimeout(usize),
+    Run(Box<FnBox>),
+}
+
+const TOKEN_MESSAGES: mio::Token = mio::Token(0);
+const TOKEN_FUTURE: mio::Token = mio::Token(1);
+const TOKEN_START: usize = 2;
+
+impl Core {
+    /// Creates a new event loop, returning any error that happened during the
+    /// creation.
+    pub fn new() -> io::Result<Core> {
+        let io = try!(mio::Poll::new());
+        let future_pair = mio::Registration::new2();
+        try!(io.register(&future_pair.0,
+                         TOKEN_FUTURE,
+                         mio::Ready::readable(),
+                         mio::PollOpt::level()));
+        let (tx, rx) = mpsc::unbounded();
+        let channel_pair = mio::Registration::new2();
+        try!(io.register(&channel_pair.0,
+                         TOKEN_MESSAGES,
+                         mio::Ready::readable(),
+                         mio::PollOpt::level()));
+        let rx_readiness = Arc::new(MySetReadiness(channel_pair.1));
+        rx_readiness.notify(0);
+
+        Ok(Core {
+            events: mio::Events::with_capacity(1024),
+            tx: tx,
+            rx: RefCell::new(executor::spawn(rx)),
+            _rx_registration: channel_pair.0,
+            rx_readiness: rx_readiness,
+
+            _future_registration: future_pair.0,
+            future_readiness: Arc::new(MySetReadiness(future_pair.1)),
+
+            inner: Rc::new(RefCell::new(Inner {
+                id: NEXT_LOOP_ID.fetch_add(1, Ordering::Relaxed),
+                io: io,
+                io_dispatch: Slab::with_capacity(1),
+                task_dispatch: Slab::with_capacity(1),
+                timeouts: Slab::with_capacity(1),
+                timer_heap: Heap::new(),
+            })),
+        })
+    }
+
+    /// Returns a handle to this event loop which cannot be sent across threads
+    /// but can be used as a proxy to the event loop itself.
+    ///
+    /// Handles are cloneable and clones always refer to the same event loop.
+    /// This handle is typically passed into functions that create I/O objects
+    /// to bind them to this event loop.
+    pub fn handle(&self) -> Handle {
+        Handle {
+            remote: reactor::Remote { sys: self.remote() },
+            inner: Rc::downgrade(&self.inner),
+        }
+    }
+
+    /// Generates a remote handle to this event loop which can be used to spawn
+    /// tasks from other threads into this event loop.
+    pub fn remote(&self) -> Remote {
+        Remote {
+            id: self.inner.borrow().id,
+            tx: self.tx.clone(),
+        }
+    }
+
+    /// Runs a future until completion, driving the event loop while we're
+    /// otherwise waiting for the future to complete.
+    ///
+    /// This function will begin executing the event loop and will finish once
+    /// the provided future is resolved. Note that the future argument here
+    /// crucially does not require the `'static` nor `Send` bounds. As a result
+    /// the future will be "pinned" to not only this thread but also this stack
+    /// frame.
+    ///
+    /// This function will return the value that the future resolves to once
+    /// the future has finished. If the future never resolves then this function
+    /// will never return.
+    ///
+    /// # Panics
+    ///
+    /// This method will **not** catch panics from polling the future `f`. If
+    /// the future panics then it's the responsibility of the caller to catch
+    /// that panic and handle it as appropriate.
+    pub fn run<F>(&mut self, f: F) -> Result<F::Item, F::Error>
+        where F: Future,
+    {
+        let mut task = executor::spawn(f);
+        let mut future_fired = true;
+
+        loop {
+            if future_fired {
+                let res = try!(CURRENT_LOOP.set(self, || {
+                    task.poll_future_notify(&self.future_readiness, 0)
+                }));
+                if let Async::Ready(e) = res {
+                    return Ok(e)
+                }
+            }
+            future_fired = self.poll(None);
+        }
+    }
+
+    /// Performs one iteration of the event loop, blocking on waiting for events
+    /// for at most `max_wait` (forever if `None`).
+    ///
+    /// It only makes sense to call this method if you've previously spawned
+    /// a future onto this event loop.
+    ///
+    /// `loop { lp.turn(None) }` is equivalent to calling `run` with an
+    /// empty future (one that never finishes).
+    pub fn turn(&mut self, max_wait: Option<Duration>) {
+        self.poll(max_wait);
+    }
+
+    fn poll(&mut self, max_wait: Option<Duration>) -> bool {
+        // Given the `max_wait` variable specified, figure out the actual
+        // timeout that we're going to pass to `poll`. This involves taking a
+        // look at active timers on our heap as well.
+        let start = Instant::now();
+        let timeout = self.inner.borrow_mut().timer_heap.peek().map(|t| {
+            if t.0 < start {
+                Duration::new(0, 0)
+            } else {
+                t.0 - start
+            }
+        });
+        let timeout = match (max_wait, timeout) {
+            (Some(d1), Some(d2)) => Some(cmp::min(d1, d2)),
+            (max_wait, timeout) => max_wait.or(timeout),
+        };
+
+        // Block waiting for an event to happen, peeling out how many events
+        // happened.
+        let amt = match self.inner.borrow_mut().io.poll(&mut self.events, timeout) {
+            Ok(a) => a,
+            Err(ref e) if e.kind() == ErrorKind::Interrupted => return false,
+            Err(e) => panic!("error in poll: {}", e),
+        };
+
+        let after_poll = Instant::now();
+        debug!("loop poll - {:?}", after_poll - start);
+        debug!("loop time - {:?}", after_poll);
+
+        // Process all timeouts that may have just occurred, updating the
+        // current time since
+        self.consume_timeouts(after_poll);
+
+        // Process all the events that came in, dispatching appropriately
+        let mut fired = false;
+        for i in 0..self.events.len() {
+            let event = self.events.get(i).unwrap();
+            let token = event.token();
+            trace!("event {:?} {:?}", event.readiness(), event.token());
+
+            if token == TOKEN_MESSAGES {
+                self.rx_readiness.0.set_readiness(mio::Ready::empty()).unwrap();
+                CURRENT_LOOP.set(&self, || self.consume_queue());
+            } else if token == TOKEN_FUTURE {
+                self.future_readiness.0.set_readiness(mio::Ready::empty()).unwrap();
+                fired = true;
+            } else {
+                self.dispatch(token, event.readiness());
+            }
+        }
+        debug!("loop process - {} events, {:?}", amt, after_poll.elapsed());
+        return fired
+    }
+
+    fn dispatch(&mut self, token: mio::Token, ready: mio::Ready) {
+        let token = usize::from(token) - TOKEN_START;
+        if token % 2 == 0 {
+            self.dispatch_io(token / 2, ready)
+        } else {
+            self.dispatch_task(token / 2)
+        }
+    }
+
+    fn dispatch_io(&mut self, token: usize, ready: mio::Ready) {
+        let mut reader = None;
+        let mut writer = None;
+        let mut inner = self.inner.borrow_mut();
+        if let Some(io) = inner.io_dispatch.get_mut(token) {
+            io.readiness.fetch_or(ready2usize(ready), Ordering::Relaxed);
+            if ready.is_writable() {
+                writer = io.writer.take();
+            }
+            if !(ready & (!mio::Ready::writable())).is_empty() {
+                reader = io.reader.take();
+            }
+        }
+        drop(inner);
+        // TODO: don't notify the same task twice
+        if let Some(reader) = reader {
+            self.notify_handle(reader);
+        }
+        if let Some(writer) = writer {
+            self.notify_handle(writer);
+        }
+    }
+
+    fn dispatch_task(&mut self, token: usize) {
+        let mut inner = self.inner.borrow_mut();
+        let (task, wake) = match inner.task_dispatch.get_mut(token) {
+            Some(slot) => (slot.spawn.take(), slot.wake.take()),
+            None => return,
+        };
+        let (mut task, wake) = match (task, wake) {
+            (Some(task), Some(wake)) => (task, wake),
+            _ => return,
+        };
+        wake.0.set_readiness(mio::Ready::empty()).unwrap();
+        drop(inner);
+        let res = CURRENT_LOOP.set(self, || {
+            task.poll_future_notify(&wake, 0)
+        });
+        let _task_to_drop;
+        inner = self.inner.borrow_mut();
+        match res {
+            Ok(Async::NotReady) => {
+                assert!(inner.task_dispatch[token].spawn.is_none());
+                inner.task_dispatch[token].spawn = Some(task);
+                inner.task_dispatch[token].wake = Some(wake);
+            }
+            Ok(Async::Ready(())) |
+            Err(()) => {
+                _task_to_drop = inner.task_dispatch.remove(token);
+            }
+        }
+        drop(inner);
+    }
+
+    fn consume_timeouts(&mut self, now: Instant) {
+        loop {
+            let mut inner = self.inner.borrow_mut();
+            match inner.timer_heap.peek() {
+                Some(head) if head.0 <= now => {}
+                Some(_) => break,
+                None => break,
+            };
+            let (_, slab_idx) = inner.timer_heap.pop().unwrap();
+
+            trace!("firing timeout: {}", slab_idx);
+            inner.timeouts[slab_idx].0.take().unwrap();
+            let handle = inner.timeouts[slab_idx].1.fire();
+            drop(inner);
+            if let Some(handle) = handle {
+                self.notify_handle(handle);
+            }
+        }
+    }
+
+    /// Method used to notify a task handle.
+    ///
+    /// Note that this should be used instead of `handle.notify()` to ensure
+    /// that the `CURRENT_LOOP` variable is set appropriately.
+    fn notify_handle(&self, handle: Task) {
+        debug!("notifying a task handle");
+        CURRENT_LOOP.set(&self, || handle.notify());
+    }
+
+    fn consume_queue(&self) {
+        debug!("consuming notification queue");
+        // TODO: can we do better than `.unwrap()` here?
+        loop {
+            let msg = self.rx.borrow_mut().poll_stream_notify(&self.rx_readiness, 0).unwrap();
+            match msg {
+                Async::Ready(Some(msg)) => self.notify(msg),
+                Async::NotReady |
+                Async::Ready(None) => break,
+            }
+        }
+    }
+
+    fn notify(&self, msg: Message) {
+        match msg {
+            Message::DropSource(tok) => self.inner.borrow_mut().drop_source(tok),
+            Message::Schedule(tok, wake, dir) => {
+                let task = self.inner.borrow_mut().schedule(tok, wake, dir);
+                if let Some(task) = task {
+                    self.notify_handle(task);
+                }
+            }
+            Message::UpdateTimeout(t, handle) => {
+                let task = self.inner.borrow_mut().update_timeout(t, handle);
+                if let Some(task) = task {
+                    self.notify_handle(task);
+                }
+            }
+            Message::ResetTimeout(t, at) => {
+                self.inner.borrow_mut().reset_timeout(t, at);
+            }
+            Message::CancelTimeout(t) => {
+                self.inner.borrow_mut().cancel_timeout(t)
+            }
+            Message::Run(r) => r.call_box(self),
+        }
+    }
+
+    /// Get the ID of this loop
+    pub fn id(&self) -> CoreId {
+        CoreId(self.inner.borrow().id)
+    }
+}
+
+impl<F> Executor<F> for Core
+    where F: Future<Item = (), Error = ()> + 'static,
+{
+    fn execute(&self, future: F) -> Result<(), ExecuteError<F>> {
+        self.handle().execute(future)
+    }
+}
+
+impl fmt::Debug for Core {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Core")
+         .field("id", &self.id())
+         .finish()
+    }
+}
+
+impl Inner {
+    fn add_source(&mut self, source: &Evented)
+                  -> io::Result<(Arc<AtomicUsize>, usize)> {
+        debug!("adding a new I/O source");
+        let sched = ScheduledIo {
+            readiness: Arc::new(AtomicUsize::new(0)),
+            reader: None,
+            writer: None,
+        };
+        if self.io_dispatch.len() == self.io_dispatch.capacity() {
+            let amt = self.io_dispatch.len();
+            self.io_dispatch.reserve_exact(amt);
+        }
+        let entry = self.io_dispatch.vacant_entry();
+        let key = entry.key();
+        try!(self.io.register(source,
+                              mio::Token(TOKEN_START + key * 2),
+                              mio::Ready::readable() |
+                                mio::Ready::writable() |
+                                platform::all(),
+                              mio::PollOpt::edge()));
+        let sched = entry.insert(sched);
+        Ok((sched.readiness.clone(), key))
+    }
+
+    fn deregister_source(&mut self, source: &Evented) -> io::Result<()> {
+        self.io.deregister(source)
+    }
+
+    fn drop_source(&mut self, token: usize) {
+        debug!("dropping I/O source: {}", token);
+        self.io_dispatch.remove(token);
+    }
+
+    fn schedule(&mut self, token: usize, wake: Task, dir: Direction)
+                -> Option<Task> {
+        debug!("scheduling direction for: {}", token);
+        let sched = self.io_dispatch.get_mut(token).unwrap();
+        let (slot, ready) = match dir {
+            Direction::Read => (&mut sched.reader, !mio::Ready::writable()),
+            Direction::Write => (&mut sched.writer, mio::Ready::writable()),
+        };
+        if sched.readiness.load(Ordering::SeqCst) & ready2usize(ready) != 0 {
+            debug!("cancelling block");
+            *slot = None;
+            Some(wake)
+        } else {
+            debug!("blocking");
+            *slot = Some(wake);
+            None
+        }
+    }
+
+    fn add_timeout(&mut self, at: Instant) -> usize {
+        if self.timeouts.len() == self.timeouts.capacity() {
+            let len = self.timeouts.len();
+            self.timeouts.reserve_exact(len);
+        }
+        let entry = self.timeouts.vacant_entry();
+        let key = entry.key();
+        let slot = self.timer_heap.push((at, key));
+        entry.insert((Some(slot), TimeoutState::NotFired));
+        debug!("added a timeout: {}", key);
+        return key;
+    }
+
+    fn update_timeout(&mut self, token: usize, handle: Task) -> Option<Task> {
+        debug!("updating a timeout: {}", token);
+        self.timeouts[token].1.block(handle)
+    }
+
+    fn reset_timeout(&mut self, token: usize, at: Instant) {
+        let pair = &mut self.timeouts[token];
+        // TODO: avoid remove + push and instead just do one sift of the heap?
+        // In theory we could update it in place and then do the percolation
+        // as necessary
+        if let Some(slot) = pair.0.take() {
+            self.timer_heap.remove(slot);
+        }
+        let slot = self.timer_heap.push((at, token));
+        *pair = (Some(slot), TimeoutState::NotFired);
+        debug!("set a timeout: {}", token);
+    }
+
+    fn cancel_timeout(&mut self, token: usize) {
+        debug!("cancel a timeout: {}", token);
+        let pair = self.timeouts.remove(token);
+        if let (Some(slot), _state) = pair {
+            self.timer_heap.remove(slot);
+        }
+    }
+
+    fn spawn(&mut self, future: Box<Future<Item=(), Error=()>>) {
+        if self.task_dispatch.len() == self.task_dispatch.capacity() {
+            let len = self.task_dispatch.len();
+            self.task_dispatch.reserve_exact(len);
+        }
+        let entry = self.task_dispatch.vacant_entry();
+        let token = TOKEN_START + 2 * entry.key() + 1;
+        let pair = mio::Registration::new2();
+        self.io.register(&pair.0,
+                         mio::Token(token),
+                         mio::Ready::readable(),
+                         mio::PollOpt::level())
+            .expect("cannot fail future registration with mio");
+        let unpark = Arc::new(MySetReadiness(pair.1));
+        unpark.notify(0);
+        entry.insert(ScheduledTask {
+            spawn: Some(executor::spawn(future)),
+            wake: Some(unpark),
+            _registration: pair.0,
+        });
+    }
+}
+
+impl Remote {
+    fn send(&self, msg: Message) {
+        self.with_loop(|lp| {
+            match lp {
+                Some(lp) => {
+                    // We want to make sure that all messages are received in
+                    // order, so we need to consume pending messages before
+                    // delivering this message to the core. The actually
+                    // `consume_queue` function, however, can be somewhat slow
+                    // right now where receiving on a channel will acquire a
+                    // lock and block the current task.
+                    //
+                    // To speed this up check the message queue's readiness as a
+                    // sort of preflight check to see if we've actually got any
+                    // messages. This should just involve some atomics and if it
+                    // comes back false then we know for sure there are no
+                    // pending messages, so we can immediately deliver our
+                    // message.
+                    if lp.rx_readiness.0.readiness().is_readable() {
+                        lp.consume_queue();
+                    }
+                    lp.notify(msg);
+                }
+                None => {
+                    match self.tx.unbounded_send(msg) {
+                        Ok(()) => {}
+
+                        // TODO: this error should punt upwards and we should
+                        //       notify the caller that the message wasn't
+                        //       received. This is tokio-core#17
+                        Err(e) => drop(e),
+                    }
+                }
+            }
+        })
+    }
+
+    fn with_loop<F, R>(&self, f: F) -> R
+        where F: FnOnce(Option<&Core>) -> R
+    {
+        if CURRENT_LOOP.is_set() {
+            CURRENT_LOOP.with(|lp| {
+                let same = lp.inner.borrow().id == self.id;
+                if same {
+                    f(Some(lp))
+                } else {
+                    f(None)
+                }
+            })
+        } else {
+            f(None)
+        }
+    }
+
+    /// Spawns a new future into the event loop this remote is associated with.
+    ///
+    /// This function takes a closure which is executed within the context of
+    /// the I/O loop itself. The future returned by the closure will be
+    /// scheduled on the event loop and run to completion.
+    ///
+    /// Note that while the closure, `F`, requires the `Send` bound as it might
+    /// cross threads, the future `R` does not.
+    ///
+    /// # Panics
+    ///
+    /// This method will **not** catch panics from polling the future `f`. If
+    /// the future panics then it's the responsibility of the caller to catch
+    /// that panic and handle it as appropriate.
+    pub fn spawn<F, R>(&self, f: F)
+        where F: FnOnce(&reactor::Handle) -> R + Send + 'static,
+              R: IntoFuture<Item=(), Error=()>,
+              R::Future: 'static,
+    {
+        self.send(Message::Run(Box::new(|lp: &Core| {
+            let f = f(&reactor::Handle { sys: lp.handle() });
+            lp.inner.borrow_mut().spawn(Box::new(f.into_future()));
+        })));
+    }
+
+    /// Return the ID of the represented Core
+    pub fn id(&self) -> CoreId {
+        CoreId(self.id)
+    }
+
+    /// Attempts to "promote" this remote to a handle, if possible.
+    ///
+    /// This function is intended for structures which typically work through a
+    /// `Remote` but want to optimize runtime when the remote doesn't actually
+    /// leave the thread of the original reactor. This will attempt to return a
+    /// handle if the `Remote` is on the same thread as the event loop and the
+    /// event loop is running.
+    ///
+    /// If this `Remote` has moved to a different thread or if the event loop is
+    /// running, then `None` may be returned. If you need to guarantee access to
+    /// a `Handle`, then you can call this function and fall back to using
+    /// `spawn` above if it returns `None`.
+    pub fn handle(&self) -> Option<Handle> {
+        if CURRENT_LOOP.is_set() {
+            CURRENT_LOOP.with(|lp| {
+                let same = lp.inner.borrow().id == self.id;
+                if same {
+                    Some(lp.handle())
+                } else {
+                    None
+                }
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl<F> Executor<F> for Remote
+    where F: Future<Item = (), Error = ()> + Send + 'static,
+{
+    fn execute(&self, future: F) -> Result<(), ExecuteError<F>> {
+        self.spawn(|_| future);
+        Ok(())
+    }
+}
+
+impl fmt::Debug for Remote {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Remote")
+         .field("id", &self.id())
+         .finish()
+    }
+}
+
+impl Handle {
+    /// Returns a reference to the underlying remote handle to the event loop.
+    pub fn remote(&self) -> &reactor::Remote {
+        &self.remote
+    }
+
+    /// Spawns a new future on the event loop this handle is associated with.
+    ///
+    /// # Panics
+    ///
+    /// This method will **not** catch panics from polling the future `f`. If
+    /// the future panics then it's the responsibility of the caller to catch
+    /// that panic and handle it as appropriate.
+    pub fn spawn<F>(&self, f: F)
+        where F: Future<Item=(), Error=()> + 'static,
+    {
+        let inner = match self.inner.upgrade() {
+            Some(inner) => inner,
+            None => return,
+        };
+        inner.borrow_mut().spawn(Box::new(f));
+    }
+
+    /// Return the ID of the represented Core
+    pub fn id(&self) -> CoreId {
+        self.remote.id()
+    }
+}
+
+impl<F> Executor<F> for Handle
+    where F: Future<Item = (), Error = ()> + 'static,
+{
+    fn execute(&self, future: F) -> Result<(), ExecuteError<F>> {
+        self.spawn(future);
+        Ok(())
+    }
+}
+
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Handle")
+         .field("id", &self.id())
+         .finish()
+    }
+}
+
+impl TimeoutState {
+    fn block(&mut self, handle: Task) -> Option<Task> {
+        match *self {
+            TimeoutState::Fired => return Some(handle),
+            _ => {}
+        }
+        *self = TimeoutState::Waiting(handle);
+        None
+    }
+
+    fn fire(&mut self) -> Option<Task> {
+        match mem::replace(self, TimeoutState::Fired) {
+            TimeoutState::NotFired => None,
+            TimeoutState::Fired => panic!("fired twice?"),
+            TimeoutState::Waiting(handle) => Some(handle),
+        }
+    }
+}
+
+struct MySetReadiness(mio::SetReadiness);
+
+impl Notify for MySetReadiness {
+    fn notify(&self, _id: usize) {
+        self.0.set_readiness(mio::Ready::readable())
+              .expect("failed to set readiness");
+    }
+}
+
+trait FnBox: Send + 'static {
+    fn call_box(self: Box<Self>, lp: &Core);
+}
+
+impl<F: FnOnce(&Core) + Send + 'static> FnBox for F {
+    fn call_box(self: Box<Self>, lp: &Core) {
+        (*self)(lp)
+    }
+}
+
+fn read_ready() -> mio::Ready {
+    mio::Ready::readable() | platform::hup()
+}
+
+const READ: usize = 1 << 0;
+const WRITE: usize = 1 << 1;
+
+fn ready2usize(ready: mio::Ready) -> usize {
+    let mut bits = 0;
+    if ready.is_readable() {
+        bits |= READ;
+    }
+    if ready.is_writable() {
+        bits |= WRITE;
+    }
+    bits | platform::ready2usize(ready)
+}
+
+fn usize2ready(bits: usize) -> mio::Ready {
+    let mut ready = mio::Ready::empty();
+    if bits & READ != 0 {
+        ready.insert(mio::Ready::readable());
+    }
+    if bits & WRITE != 0 {
+        ready.insert(mio::Ready::writable());
+    }
+    ready | platform::usize2ready(bits)
+}
+
+#[cfg(all(unix, not(target_os = "fuchsia")))]
+mod platform {
+    use mio::Ready;
+    use mio::unix::UnixReady;
+
+    pub fn aio() -> Ready {
+        UnixReady::aio().into()
+    }
+
+    pub fn all() -> Ready {
+        hup() | aio()
+    }
+
+    pub fn hup() -> Ready {
+        UnixReady::hup().into()
+    }
+
+    const HUP: usize = 1 << 2;
+    const ERROR: usize = 1 << 3;
+    const AIO: usize = 1 << 4;
+
+    pub fn ready2usize(ready: Ready) -> usize {
+        let ready = UnixReady::from(ready);
+        let mut bits = 0;
+        if ready.is_aio() {
+            bits |= AIO;
+        }
+        if ready.is_error() {
+            bits |= ERROR;
+        }
+        if ready.is_hup() {
+            bits |= HUP;
+        }
+        bits
+    }
+
+    pub fn usize2ready(bits: usize) -> Ready {
+        let mut ready = UnixReady::from(Ready::empty());
+        if bits & AIO != 0 {
+            ready.insert(UnixReady::aio());
+        }
+        if bits & HUP != 0 {
+            ready.insert(UnixReady::hup());
+        }
+        if bits & ERROR != 0 {
+            ready.insert(UnixReady::error());
+        }
+        ready.into()
+    }
+}
+
+#[cfg(any(windows, target_os = "fuchsia"))]
+mod platform {
+    use mio::Ready;
+
+    pub fn all() -> Ready {
+        // No platform-specific Readinesses for Windows
+        Ready::empty()
+    }
+
+    pub fn hup() -> Ready {
+        Ready::empty()
+    }
+
+    pub fn ready2usize(_r: Ready) -> usize {
+        0
+    }
+
+    pub fn usize2ready(_r: usize) -> Ready {
+        Ready::empty()
+    }
+}

--- a/src/reactor/mio/timeout.rs
+++ b/src/reactor/mio/timeout.rs
@@ -1,0 +1,80 @@
+//! Support for creating futures that represent timeouts.
+//!
+//! This module contains the `Timeout` type which is a future that will resolve
+//! at a particular point in the future.
+
+use std::io;
+use std::time::Instant;
+
+use futures::{Poll, Async};
+
+use reactor;
+use reactor::mio::Remote;
+use reactor::mio::timeout_token::TimeoutToken;
+
+#[derive(Debug)]
+pub struct Timeout {
+    token: TimeoutToken,
+    when: Instant,
+    handle: Remote,
+}
+
+impl Timeout {
+    /// Creates a new timeout which will fire at the time specified by `at`.
+    ///
+    /// This function will return a Result with the actual timeout object or an
+    /// error. The timeout object itself is then a future which will be
+    /// set to fire at the specified point in the future.
+    pub fn new_at(at: Instant, handle: &reactor::Handle) -> io::Result<Timeout> {
+        Ok(Timeout {
+            token: try!(TimeoutToken::new(at, handle.as_sys())),
+            when: at,
+            handle: handle.remote().clone().into_sys(),
+        })
+    }
+
+    /// Resets this timeout to an new timeout which will fire at the time
+    /// specified by `at`.
+    ///
+    /// This method is usable even of this instance of `Timeout` has "already
+    /// fired". That is, if this future has resolved, calling this method means
+    /// that the future will still re-resolve at the specified instant.
+    ///
+    /// If `at` is in the past then this future will immediately be resolved
+    /// (when `poll` is called).
+    ///
+    /// Note that if any task is currently blocked on this future then that task
+    /// will be dropped. It is required to call `poll` again after this method
+    /// has been called to ensure that a task is blocked on this future.
+    pub fn reset(&mut self, at: Instant) {
+        self.when = at;
+        self.token.reset_timeout(self.when, &self.handle);
+    }
+
+    /// Polls this `Timeout` instance to see if it's elapsed, assuming the
+    /// current time is specified by `now`.
+    ///
+    /// The `Future::poll` implementation for `Timeout` will call `Instant::now`
+    /// each time it's invoked, but in some contexts this can be a costly
+    /// operation. This method is provided to amortize the cost by avoiding
+    /// usage of `Instant::now`, assuming that it's been called elsewhere.
+    ///
+    /// This function takes the assumed current time as the first parameter and
+    /// otherwise functions as this future's `poll` function. This will block a
+    /// task if one isn't already blocked or update a previous one if already
+    /// blocked.
+    pub fn poll_at(&mut self, now: Instant) -> Poll<(), io::Error> {
+        if self.when <= now {
+            Ok(Async::Ready(()))
+        } else {
+            self.token.update_timeout(&self.handle);
+            Ok(Async::NotReady)
+        }
+    }
+}
+
+impl Drop for Timeout {
+    fn drop(&mut self) {
+        self.token.cancel_timeout(&self.handle);
+    }
+}

--- a/src/reactor/mio/timeout_token.rs
+++ b/src/reactor/mio/timeout_token.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 
 use futures::task;
 
-use reactor::{Message, Handle, Remote};
+use reactor::mio::{Message, Handle, Remote};
 
 /// A token that identifies an active timeout.
 #[derive(Debug)]

--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -4,39 +4,36 @@
 //! happening in `tokio-core`. This reactor (or event loop) is used to run
 //! futures, schedule tasks, issue I/O requests, etc.
 
-use std::cell::RefCell;
-use std::cmp;
 use std::fmt;
-use std::io::{self, ErrorKind};
-use std::mem;
-use std::rc::{Rc, Weak};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
-use std::time::{Instant, Duration};
+use std::io;
+use std::time::Duration;
 
-use futures::{Future, IntoFuture, Async};
+use futures::{Future, IntoFuture};
 use futures::future::{self, Executor, ExecuteError};
-use futures::executor::{self, Spawn, Notify};
-use futures::sync::mpsc;
-use futures::task::Task;
-use mio;
-use mio::event::Evented;
-use slab::Slab;
 
-use heap::{Heap, Slot};
+#[cfg(not(target_os = "fuchsia"))]
+mod mio;
+#[cfg(not(target_os = "fuchsia"))]
+use self::mio as sys;
 
-mod io_token;
-mod timeout_token;
+#[cfg(target_os = "fuchsia")]
+mod fuchsia;
+#[cfg(target_os = "fuchsia")]
+use self::fuchsia as sys;
+#[cfg(target_os = "fuchsia")]
+use std::sync::Arc;
 
-mod poll_evented;
 mod timeout;
 mod interval;
-pub use self::poll_evented::PollEvented;
+
+#[cfg(not(target_os = "fuchsia"))]
+pub use self::mio::PollEvented;
+
+#[cfg(target_os = "fuchsia")]
+pub use self::fuchsia::{PacketReceiver, ReceiverRegistration};
+
 pub use self::timeout::Timeout;
 pub use self::interval::Interval;
-
-static NEXT_LOOP_ID: AtomicUsize = ATOMIC_USIZE_INIT;
-scoped_thread_local!(static CURRENT_LOOP: Core);
 
 /// An event loop.
 ///
@@ -46,37 +43,7 @@ scoped_thread_local!(static CURRENT_LOOP: Core);
 /// various I/O objects to interact with the event loop in interesting ways.
 // TODO: expand this
 pub struct Core {
-    events: mio::Events,
-    tx: mpsc::UnboundedSender<Message>,
-    rx: RefCell<Spawn<mpsc::UnboundedReceiver<Message>>>,
-    _rx_registration: mio::Registration,
-    rx_readiness: Arc<MySetReadiness>,
-
-    inner: Rc<RefCell<Inner>>,
-
-    // Used for determining when the future passed to `run` is ready. Once the
-    // registration is passed to `io` above we never touch it again, just keep
-    // it alive.
-    _future_registration: mio::Registration,
-    future_readiness: Arc<MySetReadiness>,
-}
-
-struct Inner {
-    id: usize,
-    io: mio::Poll,
-
-    // Dispatch slabs for I/O and futures events
-    io_dispatch: Slab<ScheduledIo>,
-    task_dispatch: Slab<ScheduledTask>,
-
-    // Timer wheel keeping track of all timeouts. The `usize` stored in the
-    // timer wheel is an index into the slab below.
-    //
-    // The slab below keeps track of the timeouts themselves as well as the
-    // state of the timeout itself. The `TimeoutToken` type is an index into the
-    // `timeouts` slab.
-    timer_heap: Heap<(Instant, usize)>,
-    timeouts: Slab<(Option<Slot>, TimeoutState)>,
+    sys: sys::Core,
 }
 
 /// An unique ID for a Core
@@ -95,92 +62,21 @@ pub struct CoreId(usize);
 /// same underlying event loop.
 #[derive(Clone)]
 pub struct Remote {
-    id: usize,
-    tx: mpsc::UnboundedSender<Message>,
+    sys: sys::Remote,
 }
 
 /// A non-sendable handle to an event loop, useful for manufacturing instances
 /// of `LoopData`.
 #[derive(Clone)]
 pub struct Handle {
-    remote: Remote,
-    inner: Weak<RefCell<Inner>>,
+    sys: sys::Handle
 }
-
-struct ScheduledIo {
-    readiness: Arc<AtomicUsize>,
-    reader: Option<Task>,
-    writer: Option<Task>,
-}
-
-struct ScheduledTask {
-    _registration: mio::Registration,
-    spawn: Option<Spawn<Box<Future<Item=(), Error=()>>>>,
-    wake: Option<Arc<MySetReadiness>>,
-}
-
-enum TimeoutState {
-    NotFired,
-    Fired,
-    Waiting(Task),
-}
-
-enum Direction {
-    Read,
-    Write,
-}
-
-enum Message {
-    DropSource(usize),
-    Schedule(usize, Task, Direction),
-    UpdateTimeout(usize, Task),
-    ResetTimeout(usize, Instant),
-    CancelTimeout(usize),
-    Run(Box<FnBox>),
-}
-
-const TOKEN_MESSAGES: mio::Token = mio::Token(0);
-const TOKEN_FUTURE: mio::Token = mio::Token(1);
-const TOKEN_START: usize = 2;
 
 impl Core {
     /// Creates a new event loop, returning any error that happened during the
     /// creation.
     pub fn new() -> io::Result<Core> {
-        let io = try!(mio::Poll::new());
-        let future_pair = mio::Registration::new2();
-        try!(io.register(&future_pair.0,
-                         TOKEN_FUTURE,
-                         mio::Ready::readable(),
-                         mio::PollOpt::level()));
-        let (tx, rx) = mpsc::unbounded();
-        let channel_pair = mio::Registration::new2();
-        try!(io.register(&channel_pair.0,
-                         TOKEN_MESSAGES,
-                         mio::Ready::readable(),
-                         mio::PollOpt::level()));
-        let rx_readiness = Arc::new(MySetReadiness(channel_pair.1));
-        rx_readiness.notify(0);
-
-        Ok(Core {
-            events: mio::Events::with_capacity(1024),
-            tx: tx,
-            rx: RefCell::new(executor::spawn(rx)),
-            _rx_registration: channel_pair.0,
-            rx_readiness: rx_readiness,
-
-            _future_registration: future_pair.0,
-            future_readiness: Arc::new(MySetReadiness(future_pair.1)),
-
-            inner: Rc::new(RefCell::new(Inner {
-                id: NEXT_LOOP_ID.fetch_add(1, Ordering::Relaxed),
-                io: io,
-                io_dispatch: Slab::with_capacity(1),
-                task_dispatch: Slab::with_capacity(1),
-                timeouts: Slab::with_capacity(1),
-                timer_heap: Heap::new(),
-            })),
-        })
+        Ok(Core { sys: sys::Core::new()? })
     }
 
     /// Returns a handle to this event loop which cannot be sent across threads
@@ -190,19 +86,36 @@ impl Core {
     /// This handle is typically passed into functions that create I/O objects
     /// to bind them to this event loop.
     pub fn handle(&self) -> Handle {
-        Handle {
-            remote: self.remote(),
-            inner: Rc::downgrade(&self.inner),
-        }
+        Handle { sys: self.sys.handle() }
+    }
+
+    /// Returns a reference to the underlying Zircon `Port` through which packet
+    /// notifications are scheduled.
+    ///
+    /// This method is only available on Fuchsia OS.
+    #[cfg(target_os = "fuchsia")]
+    pub fn port(&self) -> &::zx::Port {
+        self.sys.port()
+    }
+
+    /// Registers the provided `PacketReceiver` with the reactor.
+    /// Returns a `ReceiverRegistration` containing the registered `PacketReceiver` as
+    /// well as a the key on which the `PacketReceiver` is registered.
+    /// 
+    /// After this function is called, users should use the `key` method on `ReceiverRegistration`
+    /// as the key for async waits on the `zx::Port` obtained by calling the `port` function.
+    /// Incoming packets will be delivered to the registered `PacketReceiver` with the matching key
+    #[cfg(target_os = "fuchsia")]
+    pub fn register_packet_receiver<T>(&self, packet_receiver: Arc<T>) -> ReceiverRegistration<T>
+        where T: PacketReceiver
+    {
+        self.sys.register_packet_receiver(packet_receiver)
     }
 
     /// Generates a remote handle to this event loop which can be used to spawn
     /// tasks from other threads into this event loop.
     pub fn remote(&self) -> Remote {
-        Remote {
-            id: self.inner.borrow().id,
-            tx: self.tx.clone(),
-        }
+        Remote { sys: self.sys.remote() }
     }
 
     /// Runs a future until completion, driving the event loop while we're
@@ -226,20 +139,7 @@ impl Core {
     pub fn run<F>(&mut self, f: F) -> Result<F::Item, F::Error>
         where F: Future,
     {
-        let mut task = executor::spawn(f);
-        let mut future_fired = true;
-
-        loop {
-            if future_fired {
-                let res = try!(CURRENT_LOOP.set(self, || {
-                    task.poll_future_notify(&self.future_readiness, 0)
-                }));
-                if let Async::Ready(e) = res {
-                    return Ok(e)
-                }
-            }
-            future_fired = self.poll(None);
-        }
+        self.sys.run(f)
     }
 
     /// Performs one iteration of the event loop, blocking on waiting for events
@@ -251,196 +151,12 @@ impl Core {
     /// `loop { lp.turn(None) }` is equivalent to calling `run` with an
     /// empty future (one that never finishes).
     pub fn turn(&mut self, max_wait: Option<Duration>) {
-        self.poll(max_wait);
-    }
-
-    fn poll(&mut self, max_wait: Option<Duration>) -> bool {
-        // Given the `max_wait` variable specified, figure out the actual
-        // timeout that we're going to pass to `poll`. This involves taking a
-        // look at active timers on our heap as well.
-        let start = Instant::now();
-        let timeout = self.inner.borrow_mut().timer_heap.peek().map(|t| {
-            if t.0 < start {
-                Duration::new(0, 0)
-            } else {
-                t.0 - start
-            }
-        });
-        let timeout = match (max_wait, timeout) {
-            (Some(d1), Some(d2)) => Some(cmp::min(d1, d2)),
-            (max_wait, timeout) => max_wait.or(timeout),
-        };
-
-        // Block waiting for an event to happen, peeling out how many events
-        // happened.
-        let amt = match self.inner.borrow_mut().io.poll(&mut self.events, timeout) {
-            Ok(a) => a,
-            Err(ref e) if e.kind() == ErrorKind::Interrupted => return false,
-            Err(e) => panic!("error in poll: {}", e),
-        };
-
-        let after_poll = Instant::now();
-        debug!("loop poll - {:?}", after_poll - start);
-        debug!("loop time - {:?}", after_poll);
-
-        // Process all timeouts that may have just occurred, updating the
-        // current time since
-        self.consume_timeouts(after_poll);
-
-        // Process all the events that came in, dispatching appropriately
-        let mut fired = false;
-        for i in 0..self.events.len() {
-            let event = self.events.get(i).unwrap();
-            let token = event.token();
-            trace!("event {:?} {:?}", event.readiness(), event.token());
-
-            if token == TOKEN_MESSAGES {
-                self.rx_readiness.0.set_readiness(mio::Ready::empty()).unwrap();
-                CURRENT_LOOP.set(&self, || self.consume_queue());
-            } else if token == TOKEN_FUTURE {
-                self.future_readiness.0.set_readiness(mio::Ready::empty()).unwrap();
-                fired = true;
-            } else {
-                self.dispatch(token, event.readiness());
-            }
-        }
-        debug!("loop process - {} events, {:?}", amt, after_poll.elapsed());
-        return fired
-    }
-
-    fn dispatch(&mut self, token: mio::Token, ready: mio::Ready) {
-        let token = usize::from(token) - TOKEN_START;
-        if token % 2 == 0 {
-            self.dispatch_io(token / 2, ready)
-        } else {
-            self.dispatch_task(token / 2)
-        }
-    }
-
-    fn dispatch_io(&mut self, token: usize, ready: mio::Ready) {
-        let mut reader = None;
-        let mut writer = None;
-        let mut inner = self.inner.borrow_mut();
-        if let Some(io) = inner.io_dispatch.get_mut(token) {
-            io.readiness.fetch_or(ready2usize(ready), Ordering::Relaxed);
-            if ready.is_writable() {
-                writer = io.writer.take();
-            }
-            if !(ready & (!mio::Ready::writable())).is_empty() {
-                reader = io.reader.take();
-            }
-        }
-        drop(inner);
-        // TODO: don't notify the same task twice
-        if let Some(reader) = reader {
-            self.notify_handle(reader);
-        }
-        if let Some(writer) = writer {
-            self.notify_handle(writer);
-        }
-    }
-
-    fn dispatch_task(&mut self, token: usize) {
-        let mut inner = self.inner.borrow_mut();
-        let (task, wake) = match inner.task_dispatch.get_mut(token) {
-            Some(slot) => (slot.spawn.take(), slot.wake.take()),
-            None => return,
-        };
-        let (mut task, wake) = match (task, wake) {
-            (Some(task), Some(wake)) => (task, wake),
-            _ => return,
-        };
-        wake.0.set_readiness(mio::Ready::empty()).unwrap();
-        drop(inner);
-        let res = CURRENT_LOOP.set(self, || {
-            task.poll_future_notify(&wake, 0)
-        });
-        let _task_to_drop;
-        inner = self.inner.borrow_mut();
-        match res {
-            Ok(Async::NotReady) => {
-                assert!(inner.task_dispatch[token].spawn.is_none());
-                inner.task_dispatch[token].spawn = Some(task);
-                inner.task_dispatch[token].wake = Some(wake);
-            }
-            Ok(Async::Ready(())) |
-            Err(()) => {
-                _task_to_drop = inner.task_dispatch.remove(token);
-            }
-        }
-        drop(inner);
-    }
-
-    fn consume_timeouts(&mut self, now: Instant) {
-        loop {
-            let mut inner = self.inner.borrow_mut();
-            match inner.timer_heap.peek() {
-                Some(head) if head.0 <= now => {}
-                Some(_) => break,
-                None => break,
-            };
-            let (_, slab_idx) = inner.timer_heap.pop().unwrap();
-
-            trace!("firing timeout: {}", slab_idx);
-            inner.timeouts[slab_idx].0.take().unwrap();
-            let handle = inner.timeouts[slab_idx].1.fire();
-            drop(inner);
-            if let Some(handle) = handle {
-                self.notify_handle(handle);
-            }
-        }
-    }
-
-    /// Method used to notify a task handle.
-    ///
-    /// Note that this should be used instead of `handle.notify()` to ensure
-    /// that the `CURRENT_LOOP` variable is set appropriately.
-    fn notify_handle(&self, handle: Task) {
-        debug!("notifying a task handle");
-        CURRENT_LOOP.set(&self, || handle.notify());
-    }
-
-    fn consume_queue(&self) {
-        debug!("consuming notification queue");
-        // TODO: can we do better than `.unwrap()` here?
-        loop {
-            let msg = self.rx.borrow_mut().poll_stream_notify(&self.rx_readiness, 0).unwrap();
-            match msg {
-                Async::Ready(Some(msg)) => self.notify(msg),
-                Async::NotReady |
-                Async::Ready(None) => break,
-            }
-        }
-    }
-
-    fn notify(&self, msg: Message) {
-        match msg {
-            Message::DropSource(tok) => self.inner.borrow_mut().drop_source(tok),
-            Message::Schedule(tok, wake, dir) => {
-                let task = self.inner.borrow_mut().schedule(tok, wake, dir);
-                if let Some(task) = task {
-                    self.notify_handle(task);
-                }
-            }
-            Message::UpdateTimeout(t, handle) => {
-                let task = self.inner.borrow_mut().update_timeout(t, handle);
-                if let Some(task) = task {
-                    self.notify_handle(task);
-                }
-            }
-            Message::ResetTimeout(t, at) => {
-                self.inner.borrow_mut().reset_timeout(t, at);
-            }
-            Message::CancelTimeout(t) => {
-                self.inner.borrow_mut().cancel_timeout(t)
-            }
-            Message::Run(r) => r.call_box(self),
-        }
+        self.sys.turn(max_wait)
     }
 
     /// Get the ID of this loop
     pub fn id(&self) -> CoreId {
-        CoreId(self.inner.borrow().id)
+        self.sys.id()
     }
 }
 
@@ -460,173 +176,28 @@ impl fmt::Debug for Core {
     }
 }
 
-impl Inner {
-    fn add_source(&mut self, source: &Evented)
-                  -> io::Result<(Arc<AtomicUsize>, usize)> {
-        debug!("adding a new I/O source");
-        let sched = ScheduledIo {
-            readiness: Arc::new(AtomicUsize::new(0)),
-            reader: None,
-            writer: None,
-        };
-        if self.io_dispatch.len() == self.io_dispatch.capacity() {
-            let amt = self.io_dispatch.len();
-            self.io_dispatch.reserve_exact(amt);
-        }
-        let entry = self.io_dispatch.vacant_entry();
-        let key = entry.key();
-        try!(self.io.register(source,
-                              mio::Token(TOKEN_START + key * 2),
-                              mio::Ready::readable() |
-                                mio::Ready::writable() |
-                                platform::all(),
-                              mio::PollOpt::edge()));
-        let sched = entry.insert(sched);
-        Ok((sched.readiness.clone(), key))
-    }
-
-    fn deregister_source(&mut self, source: &Evented) -> io::Result<()> {
-        self.io.deregister(source)
-    }
-
-    fn drop_source(&mut self, token: usize) {
-        debug!("dropping I/O source: {}", token);
-        self.io_dispatch.remove(token);
-    }
-
-    fn schedule(&mut self, token: usize, wake: Task, dir: Direction)
-                -> Option<Task> {
-        debug!("scheduling direction for: {}", token);
-        let sched = self.io_dispatch.get_mut(token).unwrap();
-        let (slot, ready) = match dir {
-            Direction::Read => (&mut sched.reader, !mio::Ready::writable()),
-            Direction::Write => (&mut sched.writer, mio::Ready::writable()),
-        };
-        if sched.readiness.load(Ordering::SeqCst) & ready2usize(ready) != 0 {
-            debug!("cancelling block");
-            *slot = None;
-            Some(wake)
-        } else {
-            debug!("blocking");
-            *slot = Some(wake);
-            None
-        }
-    }
-
-    fn add_timeout(&mut self, at: Instant) -> usize {
-        if self.timeouts.len() == self.timeouts.capacity() {
-            let len = self.timeouts.len();
-            self.timeouts.reserve_exact(len);
-        }
-        let entry = self.timeouts.vacant_entry();
-        let key = entry.key();
-        let slot = self.timer_heap.push((at, key));
-        entry.insert((Some(slot), TimeoutState::NotFired));
-        debug!("added a timeout: {}", key);
-        return key;
-    }
-
-    fn update_timeout(&mut self, token: usize, handle: Task) -> Option<Task> {
-        debug!("updating a timeout: {}", token);
-        self.timeouts[token].1.block(handle)
-    }
-
-    fn reset_timeout(&mut self, token: usize, at: Instant) {
-        let pair = &mut self.timeouts[token];
-        // TODO: avoid remove + push and instead just do one sift of the heap?
-        // In theory we could update it in place and then do the percolation
-        // as necessary
-        if let Some(slot) = pair.0.take() {
-            self.timer_heap.remove(slot);
-        }
-        let slot = self.timer_heap.push((at, token));
-        *pair = (Some(slot), TimeoutState::NotFired);
-        debug!("set a timeout: {}", token);
-    }
-
-    fn cancel_timeout(&mut self, token: usize) {
-        debug!("cancel a timeout: {}", token);
-        let pair = self.timeouts.remove(token);
-        if let (Some(slot), _state) = pair {
-            self.timer_heap.remove(slot);
-        }
-    }
-
-    fn spawn(&mut self, future: Box<Future<Item=(), Error=()>>) {
-        if self.task_dispatch.len() == self.task_dispatch.capacity() {
-            let len = self.task_dispatch.len();
-            self.task_dispatch.reserve_exact(len);
-        }
-        let entry = self.task_dispatch.vacant_entry();
-        let token = TOKEN_START + 2 * entry.key() + 1;
-        let pair = mio::Registration::new2();
-        self.io.register(&pair.0,
-                         mio::Token(token),
-                         mio::Ready::readable(),
-                         mio::PollOpt::level())
-            .expect("cannot fail future registration with mio");
-        let unpark = Arc::new(MySetReadiness(pair.1));
-        unpark.notify(0);
-        entry.insert(ScheduledTask {
-            spawn: Some(executor::spawn(future)),
-            wake: Some(unpark),
-            _registration: pair.0,
-        });
-    }
-}
-
 impl Remote {
-    fn send(&self, msg: Message) {
-        self.with_loop(|lp| {
-            match lp {
-                Some(lp) => {
-                    // We want to make sure that all messages are received in
-                    // order, so we need to consume pending messages before
-                    // delivering this message to the core. The actually
-                    // `consume_queue` function, however, can be somewhat slow
-                    // right now where receiving on a channel will acquire a
-                    // lock and block the current task.
-                    //
-                    // To speed this up check the message queue's readiness as a
-                    // sort of preflight check to see if we've actually got any
-                    // messages. This should just involve some atomics and if it
-                    // comes back false then we know for sure there are no
-                    // pending messages, so we can immediately deliver our
-                    // message.
-                    if lp.rx_readiness.0.readiness().is_readable() {
-                        lp.consume_queue();
-                    }
-                    lp.notify(msg);
-                }
-                None => {
-                    match self.tx.unbounded_send(msg) {
-                        Ok(()) => {}
-
-                        // TODO: this error should punt upwards and we should
-                        //       notify the caller that the message wasn't
-                        //       received. This is tokio-core#17
-                        Err(e) => drop(e),
-                    }
-                }
-            }
-        })
+    /// Returns a reference to the underlying Zircon `Port` through which packet
+    /// notifications are scheduled.
+    ///
+    /// This method is only available on Fuchsia OS.
+    #[cfg(target_os = "fuchsia")]
+    pub fn port(&self) -> &::zx::Port {
+        self.sys.port()
     }
 
-    fn with_loop<F, R>(&self, f: F) -> R
-        where F: FnOnce(Option<&Core>) -> R
+    /// Registers the provided `PacketReceiver` with the reactor.
+    /// Returns a `ReceiverRegistration` containing the registered `PacketReceiver` as
+    /// well as a the key on which the `PacketReceiver` is registered.
+    /// 
+    /// After this function is called, users should use the `key` method on `ReceiverRegistration`
+    /// as the key for async waits on the `zx::Port` obtained by calling the `port` function.
+    /// Incoming packets will be delivered to the registered `PacketReceiver` with the matching key.
+    #[cfg(target_os = "fuchsia")]
+    pub fn register_packet_receiver<T>(&self, packet_receiver: Arc<T>) -> ReceiverRegistration<T>
+        where T: PacketReceiver
     {
-        if CURRENT_LOOP.is_set() {
-            CURRENT_LOOP.with(|lp| {
-                let same = lp.inner.borrow().id == self.id;
-                if same {
-                    f(Some(lp))
-                } else {
-                    f(None)
-                }
-            })
-        } else {
-            f(None)
-        }
+        self.sys.register_packet_receiver(packet_receiver)
     }
 
     /// Spawns a new future into the event loop this remote is associated with.
@@ -648,15 +219,12 @@ impl Remote {
               R: IntoFuture<Item=(), Error=()>,
               R::Future: 'static,
     {
-        self.send(Message::Run(Box::new(|lp: &Core| {
-            let f = f(&lp.handle());
-            lp.inner.borrow_mut().spawn(Box::new(f.into_future()));
-        })));
+        self.sys.spawn(f)
     }
 
     /// Return the ID of the represented Core
     pub fn id(&self) -> CoreId {
-        CoreId(self.id)
+        self.sys.id()
     }
 
     /// Attempts to "promote" this remote to a handle, if possible.
@@ -672,18 +240,17 @@ impl Remote {
     /// a `Handle`, then you can call this function and fall back to using
     /// `spawn` above if it returns `None`.
     pub fn handle(&self) -> Option<Handle> {
-        if CURRENT_LOOP.is_set() {
-            CURRENT_LOOP.with(|lp| {
-                let same = lp.inner.borrow().id == self.id;
-                if same {
-                    Some(lp.handle())
-                } else {
-                    None
-                }
-            })
-        } else {
-            None
-        }
+        self.sys.handle().map(|h| Handle { sys: h })
+    }
+
+    #[cfg(not(target_os = "fuchsia"))]
+    fn into_sys(self) -> sys::Remote {
+        self.sys
+    }
+
+    #[cfg(not(target_os = "fuchsia"))]
+    fn as_sys(&self) -> &sys::Remote {
+        &self.sys
     }
 }
 
@@ -705,9 +272,32 @@ impl fmt::Debug for Remote {
 }
 
 impl Handle {
+    /// Returns a reference to the underlying Zircon `Port` through which packet
+    /// notifications are scheduled.
+    ///
+    /// This method is only available on Fuchsia OS.
+    #[cfg(target_os = "fuchsia")]
+    pub fn port(&self) -> &::zx::Port {
+        self.sys.port()
+    }
+
+    /// Registers the provided `PacketReceiver` with the reactor.
+    /// Returns a `ReceiverRegistration` containing the registered `PacketReceiver` as
+    /// well as a the key on which the `PacketReceiver` is registered.
+    /// 
+    /// After this function is called, users should use the `key` method on `ReceiverRegistration`
+    /// as the key for async waits on the `zx::Port` obtained by calling the `port` function.
+    /// Incoming packets will be delivered to the registered `PacketReceiver` with the matching key
+    #[cfg(target_os = "fuchsia")]
+    pub fn register_packet_receiver<T>(&self, packet_receiver: Arc<T>) -> ReceiverRegistration<T>
+        where T: PacketReceiver
+    {
+        self.sys.register_packet_receiver(packet_receiver)
+    } 
+
     /// Returns a reference to the underlying remote handle to the event loop.
     pub fn remote(&self) -> &Remote {
-        &self.remote
+        self.sys.remote()
     }
 
     /// Spawns a new future on the event loop this handle is associated with.
@@ -720,11 +310,7 @@ impl Handle {
     pub fn spawn<F>(&self, f: F)
         where F: Future<Item=(), Error=()> + 'static,
     {
-        let inner = match self.inner.upgrade() {
-            Some(inner) => inner,
-            None => return,
-        };
-        inner.borrow_mut().spawn(Box::new(f));
+        self.sys.spawn(f)
     }
 
     /// Spawns a closure on this event loop.
@@ -748,7 +334,13 @@ impl Handle {
 
     /// Return the ID of the represented Core
     pub fn id(&self) -> CoreId {
-        self.remote.id()
+        self.sys.id()
+    }
+
+    /// Borrows this handle as its system-specific representation.
+    #[cfg(not(target_os = "fuchsia"))]
+    pub(crate) fn as_sys(&self) -> &sys::Handle {
+        &self.sys
     }
 }
 
@@ -766,145 +358,5 @@ impl fmt::Debug for Handle {
         f.debug_struct("Handle")
          .field("id", &self.id())
          .finish()
-    }
-}
-
-impl TimeoutState {
-    fn block(&mut self, handle: Task) -> Option<Task> {
-        match *self {
-            TimeoutState::Fired => return Some(handle),
-            _ => {}
-        }
-        *self = TimeoutState::Waiting(handle);
-        None
-    }
-
-    fn fire(&mut self) -> Option<Task> {
-        match mem::replace(self, TimeoutState::Fired) {
-            TimeoutState::NotFired => None,
-            TimeoutState::Fired => panic!("fired twice?"),
-            TimeoutState::Waiting(handle) => Some(handle),
-        }
-    }
-}
-
-struct MySetReadiness(mio::SetReadiness);
-
-impl Notify for MySetReadiness {
-    fn notify(&self, _id: usize) {
-        self.0.set_readiness(mio::Ready::readable())
-              .expect("failed to set readiness");
-    }
-}
-
-trait FnBox: Send + 'static {
-    fn call_box(self: Box<Self>, lp: &Core);
-}
-
-impl<F: FnOnce(&Core) + Send + 'static> FnBox for F {
-    fn call_box(self: Box<Self>, lp: &Core) {
-        (*self)(lp)
-    }
-}
-
-fn read_ready() -> mio::Ready {
-    mio::Ready::readable() | platform::hup()
-}
-
-const READ: usize = 1 << 0;
-const WRITE: usize = 1 << 1;
-
-fn ready2usize(ready: mio::Ready) -> usize {
-    let mut bits = 0;
-    if ready.is_readable() {
-        bits |= READ;
-    }
-    if ready.is_writable() {
-        bits |= WRITE;
-    }
-    bits | platform::ready2usize(ready)
-}
-
-fn usize2ready(bits: usize) -> mio::Ready {
-    let mut ready = mio::Ready::empty();
-    if bits & READ != 0 {
-        ready.insert(mio::Ready::readable());
-    }
-    if bits & WRITE != 0 {
-        ready.insert(mio::Ready::writable());
-    }
-    ready | platform::usize2ready(bits)
-}
-
-#[cfg(all(unix, not(target_os = "fuchsia")))]
-mod platform {
-    use mio::Ready;
-    use mio::unix::UnixReady;
-
-    pub fn aio() -> Ready {
-        UnixReady::aio().into()
-    }
-
-    pub fn all() -> Ready {
-        hup() | aio()
-    }
-
-    pub fn hup() -> Ready {
-        UnixReady::hup().into()
-    }
-
-    const HUP: usize = 1 << 2;
-    const ERROR: usize = 1 << 3;
-    const AIO: usize = 1 << 4;
-
-    pub fn ready2usize(ready: Ready) -> usize {
-        let ready = UnixReady::from(ready);
-        let mut bits = 0;
-        if ready.is_aio() {
-            bits |= AIO;
-        }
-        if ready.is_error() {
-            bits |= ERROR;
-        }
-        if ready.is_hup() {
-            bits |= HUP;
-        }
-        bits
-    }
-
-    pub fn usize2ready(bits: usize) -> Ready {
-        let mut ready = UnixReady::from(Ready::empty());
-        if bits & AIO != 0 {
-            ready.insert(UnixReady::aio());
-        }
-        if bits & HUP != 0 {
-            ready.insert(UnixReady::hup());
-        }
-        if bits & ERROR != 0 {
-            ready.insert(UnixReady::error());
-        }
-        ready.into()
-    }
-}
-
-#[cfg(any(windows, target_os = "fuchsia"))]
-mod platform {
-    use mio::Ready;
-
-    pub fn all() -> Ready {
-        // No platform-specific Readinesses for Windows
-        Ready::empty()
-    }
-
-    pub fn hup() -> Ready {
-        Ready::empty()
-    }
-
-    pub fn ready2usize(_r: Ready) -> usize {
-        0
-    }
-
-    pub fn usize2ready(_r: usize) -> Ready {
-        Ready::empty()
     }
 }

--- a/tests/pipe-hup.rs
+++ b/tests/pipe-hup.rs
@@ -1,4 +1,4 @@
-#![cfg(unix)]
+#![cfg(all(unix, not(target_os = "fuchsia")))]
 
 extern crate env_logger;
 extern crate futures;


### PR DESCRIPTION
This change splits out the reactor into separate mio-based and Fuchsia-ports-based implementations. This is greatly beneficial to Fuchsia's uses of tokio-core, as it allows us to schedule and receive custom notifications via the `PacketReceiver` interface. After this change, the Fuchsia backend for mio will no longer be used by tokio-core.

I apologize this is so much code-- I wanted to do this all at once so that I could see how all the different pieces came together. I hope that the Fuchsia components are isolated enough that it doesn't impose too great of a maintenance burden.

cc @raggi, @raphlinus, @alexcrichton, @carllerche