### PR TITLE
use 64 iovecs in TcpStream::write_buf

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -694,12 +694,7 @@ impl<'a> AsyncWrite for &'a TcpStream {
             // `bytes_vec` method.
             static DUMMY: &[u8] = &[0];
             let iovec = <&IoVec>::from(DUMMY);
-            let mut bufs = [
-                iovec, iovec, iovec, iovec,
-                iovec, iovec, iovec, iovec,
-                iovec, iovec, iovec, iovec,
-                iovec, iovec, iovec, iovec,
-            ];
+            let mut bufs = [iovec; 64];
             let n = buf.bytes_vec(&mut bufs);
             self.io.get_ref().write_bufs(&bufs[..n])
         };


### PR DESCRIPTION
Some background: while switching to `write_buf` in hyper, I noticed the 16 pipelined requests benchmark suffered since the responses where split of 32 buffers (1 headers + 1 body * 16 responses), and so each syscall was only writing half as many responses as when hyper flattens all into a single buffer first.

The easiest knee-jerk reaction is to increase the amount of `IoVec`s used in `TcpStream::write_buf`. I arbitrarily picked 64. The man page for `writev(2)` mentions that the default max in Linux is 1024...

A longer term fix could be to add an associated constant to `Buf`, to allow an implementer to state how many `IoVec`s they expect to need.