### PR TITLE
deny warnings only in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 
 env:
   global:
-    - RUSTFLAGS='--cfg assert_timer_heap_consistent'
+    - RUSTFLAGS='--cfg assert_timer_heap_consistent -D warnings'
     - secure: "gOETHEX34re+YOgwdPG+wxSWZ1Nn5Q4+pk5b3mpaPS2RRVLdNlm7oJFYJMp1MsO3r4t5z4ntpBQUy/rQXPzzSOUqb0E+wnOtAFD+rspY0z5rJMwOghfdNst/Jsa5+EJeGWHEXd6YNdH1fILg94OCzzzmdjQH59F5UqRtY4EfMZQ9BzxuH0nNrCtys4xf0fstmlezw6mCyKR7DL2JxMf7ux10JeCTsj8BCT/yFKZ4HhFiKGVUpWSSTY3+lESnI4rKLynZEnFAkrHlIMyNRXf+lLfoTCTdmG0LAjf4AMsxLA9sSHVEhz9gvazQB4lX4B+E2Tuq1v/QecKqpRvfb4nM+ldRrsIW6zNf5DGA4J07h1qnhB0DO0TftDNuZNArueDW/yaeO5u6M4TspozdKYRx8QVvHg609WEdQPiDg4HdR2EUHyGBYbWJTVoBbYM+Yv3Pa1zBw8r/82sH4SGj1GtBFfH4QxTwMzGpX8AF4l2HUUFlpLgCrrWwTCwTxuQUsvjUPfrKHIisZPFGeu92qjmMN+YZh8U1a/W9xOLFbrTOH+FVRt9XrkT2Cwtfcia/7TMS2kXWyxrz82zpAwL5SEpP0k84B7GqLGlZrCKboufMBrtE6Chycp2D2quyVM0/kF5x2ev6QHToT1FH2McVB1XwkxJNeCMZhOe4EDpyfovPweQ="
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 environment:
+  RUSTFLAGS: -D warnings
   matrix:
   - TARGET: x86_64-pc-windows-msvc
 install:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,6 @@
 
 #![doc(html_root_url = "https://docs.rs/tokio-core/0.1")]
 #![deny(missing_docs)]
-#![deny(warnings)]
-#![cfg_attr(test, allow(deprecated))]
 
 extern crate bytes;
 #[macro_use]


### PR DESCRIPTION
It's very unpleasant when after library update in distribution, crate
stops building just because some new warning appears.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>