### PR TITLE
lio_listio support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ appveyor = { repository = "alexcrichton/tokio-core" }
 [dependencies]
 bytes = "0.4"
 log = "0.4"
-mio = { git = "https://github.com/carllerche/mio", rev = "726b1f3078e79e69c3961f8af32e76e06c49a3f2" }
+mio = "0.6.13"
 scoped-tls = "0.1.0"
 slab = "0.4"
 iovec = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ appveyor = { repository = "alexcrichton/tokio-core" }
 [dependencies]
 bytes = "0.4"
 log = "0.4"
-mio = "0.6.12"
+mio = { git = "https://github.com/carllerche/mio", rev = "726b1f3078e79e69c3961f8af32e76e06c49a3f2" }
 scoped-tls = "0.1.0"
 slab = "0.4"
 iovec = "0.1"

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -156,9 +156,9 @@ impl TcpListener {
     ///   `addr` is an IPv4 address then all sockets accepted will be IPv4 as
     ///   well (same for IPv6).
     pub fn from_listener(listener: net::TcpListener,
-                         addr: &SocketAddr,
+                         _: &SocketAddr,
                          handle: &Handle) -> io::Result<TcpListener> {
-        let l = try!(mio::net::TcpListener::from_listener(listener, addr));
+        let l = try!(mio::net::TcpListener::from_std(listener));
         TcpListener::new(l, handle)
     }
 

--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -840,9 +840,14 @@ mod platform {
     use mio::Ready;
     use mio::unix::UnixReady;
 
-    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+    #[cfg(target_os = "dragonfly")]
     pub fn all() -> Ready {
         hup() | UnixReady::aio()
+    }
+
+    #[cfg(target_os = "freebsd")]
+    pub fn all() -> Ready {
+        hup() | UnixReady::aio() | UnixReady::lio()
     }
 
     #[cfg(not(any(target_os = "dragonfly", target_os = "freebsd")))]
@@ -857,6 +862,7 @@ mod platform {
     const HUP: usize = 1 << 2;
     const ERROR: usize = 1 << 3;
     const AIO: usize = 1 << 4;
+    const LIO: usize = 1 << 5;
 
     #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
     fn is_aio(ready: &Ready) -> bool {
@@ -868,11 +874,24 @@ mod platform {
         false
     }
 
+    #[cfg(target_os = "freebsd")]
+    fn is_lio(ready: &Ready) -> bool {
+        UnixReady::from(*ready).is_lio()
+    }
+
+    #[cfg(not(target_os = "freebsd"))]
+    fn is_lio(_ready: &Ready) -> bool {
+        false
+    }
+
     pub fn ready2usize(ready: Ready) -> usize {
         let ready = UnixReady::from(ready);
         let mut bits = 0;
         if is_aio(&ready) {
             bits |= AIO;
+        }
+        if is_lio(&ready) {
+            bits |= LIO;
         }
         if ready.is_error() {
             bits |= ERROR;
@@ -895,8 +914,21 @@ mod platform {
         // aio not available here → empty
     }
 
+    #[cfg(target_os = "freebsd")]
+    fn usize2ready_lio(ready: &mut UnixReady) {
+        ready.insert(UnixReady::lio());
+    }
+
+    #[cfg(not(target_os = "freebsd"))]
+    fn usize2ready_lio(_ready: &mut UnixReady) {
+        // lio not available here → empty
+    }
+
     pub fn usize2ready(bits: usize) -> Ready {
         let mut ready = UnixReady::from(Ready::empty());
+        if bits & LIO != 0 {
+            usize2ready_lio(&mut ready);
+        }
         if bits & AIO != 0 {
             usize2ready_aio(&mut ready);
         }


### PR DESCRIPTION
This adds support for lio_listio(2), a way of submitting multiple aio_read(2), aio_write(2), and/or aio_fsync(2) operations in a single system call.  Higher level support will be provided by the tokio-file crate.