### PR TITLE
Update crate to use Tokio reform internally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,9 @@ scoped-tls = "0.1.0"
 slab = "0.4"
 iovec = "0.1"
 tokio-io = "0.1"
-tokio = { git = "https://github.com/tokio-rs/tokio" }
-tokio-executor = { git = "https://github.com/tokio-rs/tokio" }
+tokio = { git = "https://github.com/tokio-rs/tokio", branch = "explicit-spawn-fn" }
+tokio-executor = { git = "https://github.com/tokio-rs/tokio", branch = "explicit-spawn-fn" }
+tokio-reactor = { git = "https://github.com/tokio-rs/tokio", branch = "explicit-spawn-fn" }
 futures = "0.1.16"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ scoped-tls = "0.1.0"
 slab = "0.4"
 iovec = "0.1"
 tokio-io = "0.1"
-tokio = { git = "https://github.com/tokio-rs/tokio", branch = "explicit-spawn-fn" }
-tokio-executor = { git = "https://github.com/tokio-rs/tokio", branch = "explicit-spawn-fn" }
-tokio-reactor = { git = "https://github.com/tokio-rs/tokio", branch = "explicit-spawn-fn" }
-futures = "0.1.16"
+tokio = "0.1.2"
+tokio-executor = "0.1.0"
+tokio-reactor = "0.1.0"
+futures = "0.1.18"
 
 [dev-dependencies]
 env_logger = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-core"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/tokio-rs/tokio-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ scoped-tls = "0.1.0"
 slab = "0.4"
 iovec = "0.1"
 tokio-io = "0.1"
-tokio = "0.1.2"
-tokio-executor = "0.1.0"
+tokio = { git = "https://github.com/tokio-rs/tokio" }
+tokio-executor = { git = "https://github.com/tokio-rs/tokio" }
 futures = "0.1.16"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ scoped-tls = "0.1.0"
 slab = "0.4"
 iovec = "0.1"
 tokio-io = "0.1"
+tokio = "0.1.2"
+tokio-executor = "0.1.0"
 futures = "0.1.16"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ extern crate slab;
 extern crate tokio;
 extern crate tokio_executor;
 extern crate tokio_io;
+extern crate tokio_reactor;
 
 #[macro_use]
 extern crate scoped_tls;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,7 @@
 
 #![doc(html_root_url = "https://docs.rs/tokio-core/0.1")]
 #![deny(missing_docs)]
-// #![deny(warnings)]
-#![allow(warnings)]
+#![deny(warnings)]
 #![cfg_attr(test, allow(deprecated))]
 
 extern crate bytes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 //! }
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/tokio-core/0.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-core/0.1.13")]
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![cfg_attr(test, allow(deprecated))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,8 @@
 
 #![doc(html_root_url = "https://docs.rs/tokio-core/0.1")]
 #![deny(missing_docs)]
-#![deny(warnings)]
+// #![deny(warnings)]
+#![allow(warnings)]
 #![cfg_attr(test, allow(deprecated))]
 
 extern crate bytes;
@@ -100,6 +101,8 @@ extern crate futures;
 extern crate iovec;
 extern crate mio;
 extern crate slab;
+extern crate tokio;
+extern crate tokio_executor;
 extern crate tokio_io;
 
 #[macro_use]

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -89,7 +89,7 @@ impl UdpSocket {
             Ok(n) => Ok(n),
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.clear_write_ready();
+                    self.io.clear_write_ready()?;
                 }
                 Err(e)
             }
@@ -106,7 +106,7 @@ impl UdpSocket {
             Ok(n) => Ok(n),
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.clear_read_ready(mio::Ready::readable());
+                    self.io.clear_read_ready(mio::Ready::readable())?;
                 }
                 Err(e)
             }
@@ -162,7 +162,7 @@ impl UdpSocket {
             Ok(n) => Ok(n),
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.clear_write_ready();
+                    self.io.clear_write_ready()?;
                 }
                 Err(e)
             }
@@ -200,7 +200,7 @@ impl UdpSocket {
             Ok(n) => Ok(n),
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.clear_read_ready(mio::Ready::readable());
+                    self.io.clear_read_ready(mio::Ready::readable())?;
                 }
                 Err(e)
             }

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -5,11 +5,11 @@ use std::fmt;
 use futures::{Async, Future, Poll};
 use mio;
 
-use reactor::{Handle, PollEvented};
+use reactor::{Handle, PollEvented2};
 
 /// An I/O object representing a UDP socket.
 pub struct UdpSocket {
-    io: PollEvented<mio::net::UdpSocket>,
+    io: PollEvented2<mio::net::UdpSocket>,
 }
 
 mod frame;
@@ -26,7 +26,7 @@ impl UdpSocket {
     }
 
     fn new(socket: mio::net::UdpSocket, handle: &Handle) -> io::Result<UdpSocket> {
-        let io = try!(PollEvented::new(socket, handle));
+        let io = try!(PollEvented2::new_with_handle(socket, handle.new_tokio_handle()));
         Ok(UdpSocket { io: io })
     }
 
@@ -82,7 +82,7 @@ impl UdpSocket {
     /// Sends data on the socket to the address previously bound via connect().
     /// On success, returns the number of bytes written.
     pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
-        if let Async::NotReady = self.io.poll_write() {
+        if let Async::NotReady = self.io.poll_write_ready()? {
             return Err(io::ErrorKind::WouldBlock.into())
         }
         match self.io.get_ref().send(buf) {
@@ -99,7 +99,7 @@ impl UdpSocket {
     /// Receives data from the socket previously bound with connect().
     /// On success, returns the number of bytes read.
     pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        if let Async::NotReady = self.io.poll_read() {
+        if let Async::NotReady = self.io.poll_read_ready()? {
             return Err(io::ErrorKind::WouldBlock.into())
         }
         match self.io.get_ref().recv(buf) {
@@ -120,7 +120,15 @@ impl UdpSocket {
     /// is only suitable for calling in a `Future::poll` method and will
     /// automatically handle ensuring a retry once the socket is readable again.
     pub fn poll_read(&self) -> Async<()> {
-        self.io.poll_read()
+        self.io.poll_read_ready()
+            .map(|r| {
+                if r.is_ready() {
+                    Async::Ready(())
+                } else {
+                    Async::NotReady
+                }
+            })
+            .unwrap_or(().into())
     }
 
     /// Test whether this socket is ready to be written to or not.
@@ -130,7 +138,15 @@ impl UdpSocket {
     /// is only suitable for calling in a `Future::poll` method and will
     /// automatically handle ensuring a retry once the socket is writable again.
     pub fn poll_write(&self) -> Async<()> {
-        self.io.poll_write()
+        self.io.poll_write_ready()
+            .map(|r| {
+                if r.is_ready() {
+                    Async::Ready(())
+                } else {
+                    Async::NotReady
+                }
+            })
+            .unwrap_or(().into())
     }
 
     /// Sends data on the socket to the given address. On success, returns the
@@ -139,7 +155,7 @@ impl UdpSocket {
     /// Address type can be any implementer of `ToSocketAddrs` trait. See its
     /// documentation for concrete examples.
     pub fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
-        if let Async::NotReady = self.io.poll_write() {
+        if let Async::NotReady = self.io.poll_write_ready()? {
             return Err(io::ErrorKind::WouldBlock.into())
         }
         match self.io.get_ref().send_to(buf, target) {
@@ -177,7 +193,7 @@ impl UdpSocket {
     /// Receives data from the socket. On success, returns the number of bytes
     /// read and the address from whence the data came.
     pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
-        if let Async::NotReady = self.io.poll_read() {
+        if let Async::NotReady = self.io.poll_read_ready()? {
             return Err(io::ErrorKind::WouldBlock.into())
         }
         match self.io.get_ref().recv_from(buf) {

--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -815,15 +815,6 @@ mod platform {
 mod platform {
     use mio::Ready;
 
-    pub fn all() -> Ready {
-        // No platform-specific Readinesses for Windows
-        Ready::empty()
-    }
-
-    pub fn hup() -> Ready {
-        Ready::empty()
-    }
-
     pub fn ready2usize(_r: Ready) -> usize {
         0
     }

--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -11,8 +11,13 @@ use std::io::{self, ErrorKind};
 use std::mem;
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use std::sync::atomic::{AtomicUsize, AtomicBool, ATOMIC_USIZE_INIT, Ordering};
 use std::time::{Instant, Duration};
+
+use tokio;
+use tokio::executor::current_thread::{CurrentThread, TaskExecutor};
+use tokio_executor;
+use tokio_executor::park::{Park, Unpark, ParkThread, UnparkThread};
 
 use futures::{Future, IntoFuture, Async};
 use futures::future::{self, Executor, ExecuteError};
@@ -25,13 +30,14 @@ use slab::Slab;
 
 use heap::{Heap, Slot};
 
-mod io_token;
 mod timeout_token;
 
 mod poll_evented;
+mod poll_evented2;
 mod timeout;
 mod interval;
 pub use self::poll_evented::PollEvented;
+pub(crate) use self::poll_evented2::PollEvented as PollEvented2;
 pub use self::timeout::Timeout;
 pub use self::interval::Interval;
 
@@ -46,28 +52,34 @@ scoped_thread_local!(static CURRENT_LOOP: Core);
 /// various I/O objects to interact with the event loop in interesting ways.
 // TODO: expand this
 pub struct Core {
-    events: mio::Events,
+    /// Uniquely identifies the reactor
+    id: usize,
+
+    /// Handle to the Tokio runtime
+    rt: tokio::runtime::Runtime,
+
+    /// Executes tasks
+    executor: RefCell<CurrentThread>,
+
+    /// Wakes up the thread when the `run` future is notified
+    notify_future: Arc<MyNotify>,
+
+    /// Wakes up the thread when a message is posted to `rx`
+    notify_rx: Arc<MyNotify>,
+
+    /// Send messages across threads to the core
     tx: mpsc::UnboundedSender<Message>,
+
+    /// Receive messages
     rx: RefCell<Spawn<mpsc::UnboundedReceiver<Message>>>,
-    _rx_registration: mio::Registration,
-    rx_readiness: Arc<MySetReadiness>,
 
+    // Shared inner state
     inner: Rc<RefCell<Inner>>,
-
-    // Used for determining when the future passed to `run` is ready. Once the
-    // registration is passed to `io` above we never touch it again, just keep
-    // it alive.
-    _future_registration: mio::Registration,
-    future_readiness: Arc<MySetReadiness>,
 }
 
 struct Inner {
-    id: usize,
-    io: mio::Poll,
-
-    // Dispatch slabs for I/O and futures events
-    io_dispatch: Slab<ScheduledIo>,
-    task_dispatch: Slab<ScheduledTask>,
+    // Tasks that need to be spawned onto the executor.
+    pending_spawn: Vec<Box<Future<Item = (), Error = ()>>>,
 
     // Timer wheel keeping track of all timeouts. The `usize` stored in the
     // timer wheel is an index into the slab below.
@@ -97,6 +109,7 @@ pub struct CoreId(usize);
 pub struct Remote {
     id: usize,
     tx: mpsc::UnboundedSender<Message>,
+    new_handle: tokio::reactor::Handle,
 }
 
 /// A non-sendable handle to an event loop, useful for manufacturing instances
@@ -107,76 +120,59 @@ pub struct Handle {
     inner: Weak<RefCell<Inner>>,
 }
 
-struct ScheduledIo {
-    readiness: Arc<AtomicUsize>,
-    reader: Option<Task>,
-    writer: Option<Task>,
-}
-
-struct ScheduledTask {
-    _registration: mio::Registration,
-    spawn: Option<Spawn<Box<Future<Item=(), Error=()>>>>,
-    wake: Option<Arc<MySetReadiness>>,
-}
-
 enum TimeoutState {
     NotFired,
     Fired,
     Waiting(Task),
 }
 
-enum Direction {
-    Read,
-    Write,
-}
-
 enum Message {
-    DropSource(usize),
-    Schedule(usize, Task, Direction),
     UpdateTimeout(usize, Task),
     ResetTimeout(usize, Instant),
     CancelTimeout(usize),
     Run(Box<FnBox>),
 }
 
-const TOKEN_MESSAGES: mio::Token = mio::Token(0);
-const TOKEN_FUTURE: mio::Token = mio::Token(1);
-const TOKEN_START: usize = 2;
+const TOKEN_MESSAGES: usize = 0;
+const TOKEN_FUTURE: usize = 1;
+
+// ===== impl Core =====
 
 impl Core {
     /// Creates a new event loop, returning any error that happened during the
     /// creation.
     pub fn new() -> io::Result<Core> {
-        let io = try!(mio::Poll::new());
-        let future_pair = mio::Registration::new2();
-        try!(io.register(&future_pair.0,
-                         TOKEN_FUTURE,
-                         mio::Ready::readable(),
-                         mio::PollOpt::level()));
+        // Create a new parker
+        let park = ParkThread::new();
+
+        // Create notifiers
+        let notify_future = Arc::new(MyNotify::new(park.unpark()));
+        let notify_rx = Arc::new(MyNotify::new(park.unpark()));
+
+        // New Tokio reactor + threadpool
+        let rt = tokio::runtime::Runtime::new()?;
+
+        // Executor to run !Send futures
+        let executor = RefCell::new(CurrentThread::new_with_park(park));
+
+        // Used to send messages across threads
         let (tx, rx) = mpsc::unbounded();
-        let channel_pair = mio::Registration::new2();
-        try!(io.register(&channel_pair.0,
-                         TOKEN_MESSAGES,
-                         mio::Ready::readable(),
-                         mio::PollOpt::level()));
-        let rx_readiness = Arc::new(MySetReadiness(channel_pair.1));
-        rx_readiness.notify(0);
+
+        // Wrap the rx half with a future context and refcell
+        let rx = RefCell::new(executor::spawn(rx));
+
+        let id = NEXT_LOOP_ID.fetch_add(1, Ordering::Relaxed);
 
         Ok(Core {
-            events: mio::Events::with_capacity(1024),
-            tx: tx,
-            rx: RefCell::new(executor::spawn(rx)),
-            _rx_registration: channel_pair.0,
-            rx_readiness: rx_readiness,
-
-            _future_registration: future_pair.0,
-            future_readiness: Arc::new(MySetReadiness(future_pair.1)),
-
+            id,
+            rt,
+            notify_future,
+            notify_rx,
+            tx,
+            rx,
+            executor,
             inner: Rc::new(RefCell::new(Inner {
-                id: NEXT_LOOP_ID.fetch_add(1, Ordering::Relaxed),
-                io: io,
-                io_dispatch: Slab::with_capacity(1),
-                task_dispatch: Slab::with_capacity(1),
+                pending_spawn: vec![],
                 timeouts: Slab::with_capacity(1),
                 timer_heap: Heap::new(),
             })),
@@ -200,8 +196,9 @@ impl Core {
     /// tasks from other threads into this event loop.
     pub fn remote(&self) -> Remote {
         Remote {
-            id: self.inner.borrow().id,
+            id: self.id,
             tx: self.tx.clone(),
+            new_handle: self.rt.handle().clone(),
         }
     }
 
@@ -227,18 +224,21 @@ impl Core {
         where F: Future,
     {
         let mut task = executor::spawn(f);
-        let mut future_fired = true;
+
+        // Make sure the future will run at least once on enter
+        self.notify_future.notify(0);
 
         loop {
-            if future_fired {
+            if self.notify_future.take() {
                 let res = try!(CURRENT_LOOP.set(self, || {
-                    task.poll_future_notify(&self.future_readiness, 0)
+                    task.poll_future_notify(&self.notify_future, 0)
                 }));
                 if let Async::Ready(e) = res {
                     return Ok(e)
                 }
             }
-            future_fired = self.poll(None);
+
+            self.poll(None);
         }
     }
 
@@ -254,7 +254,10 @@ impl Core {
         self.poll(max_wait);
     }
 
-    fn poll(&mut self, max_wait: Option<Duration>) -> bool {
+    fn poll(&mut self, max_wait: Option<Duration>) {
+        let mut enter = tokio_executor::enter()
+            .ok().expect("cannot recursively call into `Core`");
+
         // Given the `max_wait` variable specified, figure out the actual
         // timeout that we're going to pass to `poll`. This involves taking a
         // look at active timers on our heap as well.
@@ -271,13 +274,26 @@ impl Core {
             (max_wait, timeout) => max_wait.or(timeout),
         };
 
-        // Block waiting for an event to happen, peeling out how many events
-        // happened.
-        let amt = match self.inner.borrow_mut().io.poll(&mut self.events, timeout) {
-            Ok(a) => a,
-            Err(ref e) if e.kind() == ErrorKind::Interrupted => return false,
-            Err(e) => panic!("error in poll: {}", e),
-        };
+        // Drain any futures pending spawn
+        {
+            let mut e = self.executor.borrow_mut();
+            let mut i = self.inner.borrow_mut();
+
+            for f in i.pending_spawn.drain(..) {
+                // Little hack
+                e.enter(&mut enter).block_on(future::lazy(|| {
+                    TaskExecutor::current().spawn_local(f).unwrap();
+                    Ok::<_, ()>(())
+                })).unwrap();
+            }
+        }
+
+        CURRENT_LOOP.set(self, || {
+            self.executor.borrow_mut()
+                .enter(&mut enter)
+                .turn(timeout)
+                .ok().expect("error in `CurrentThread::turn`");
+        });
 
         let after_poll = Instant::now();
         debug!("loop poll - {:?}", after_poll - start);
@@ -288,86 +304,11 @@ impl Core {
         self.consume_timeouts(after_poll);
 
         // Process all the events that came in, dispatching appropriately
-        let mut fired = false;
-        for event in &self.events {
-            let token = event.token();
-            trace!("event {:?} {:?}", event.readiness(), event.token());
+        if self.notify_rx.take() {
+            CURRENT_LOOP.set(self, || self.consume_queue());
+        }
 
-            if token == TOKEN_MESSAGES {
-                self.rx_readiness.0.set_readiness(mio::Ready::empty()).unwrap();
-                CURRENT_LOOP.set(&self, || self.consume_queue());
-            } else if token == TOKEN_FUTURE {
-                self.future_readiness.0.set_readiness(mio::Ready::empty()).unwrap();
-                fired = true;
-            } else {
-                self.dispatch(token, event.readiness());
-            }
-        }
-        debug!("loop process - {} events, {:?}", amt, after_poll.elapsed());
-        return fired
-    }
-
-    fn dispatch(&self, token: mio::Token, ready: mio::Ready) {
-        let token = usize::from(token) - TOKEN_START;
-        if token % 2 == 0 {
-            self.dispatch_io(token / 2, ready)
-        } else {
-            self.dispatch_task(token / 2)
-        }
-    }
-
-    fn dispatch_io(&self, token: usize, ready: mio::Ready) {
-        let mut reader = None;
-        let mut writer = None;
-        let mut inner = self.inner.borrow_mut();
-        if let Some(io) = inner.io_dispatch.get_mut(token) {
-            io.readiness.fetch_or(ready2usize(ready), Ordering::Relaxed);
-            if ready.is_writable() {
-                writer = io.writer.take();
-            }
-            if !(ready & (!mio::Ready::writable())).is_empty() {
-                reader = io.reader.take();
-            }
-        }
-        drop(inner);
-        // TODO: don't notify the same task twice
-        if let Some(reader) = reader {
-            self.notify_handle(reader);
-        }
-        if let Some(writer) = writer {
-            self.notify_handle(writer);
-        }
-    }
-
-    fn dispatch_task(&self, token: usize) {
-        let mut inner = self.inner.borrow_mut();
-        let (task, wake) = match inner.task_dispatch.get_mut(token) {
-            Some(slot) => (slot.spawn.take(), slot.wake.take()),
-            None => return,
-        };
-        let (mut task, wake) = match (task, wake) {
-            (Some(task), Some(wake)) => (task, wake),
-            _ => return,
-        };
-        wake.0.set_readiness(mio::Ready::empty()).unwrap();
-        drop(inner);
-        let res = CURRENT_LOOP.set(self, || {
-            task.poll_future_notify(&wake, 0)
-        });
-        let _task_to_drop;
-        inner = self.inner.borrow_mut();
-        match res {
-            Ok(Async::NotReady) => {
-                assert!(inner.task_dispatch[token].spawn.is_none());
-                inner.task_dispatch[token].spawn = Some(task);
-                inner.task_dispatch[token].wake = Some(wake);
-            }
-            Ok(Async::Ready(())) |
-            Err(()) => {
-                _task_to_drop = inner.task_dispatch.remove(token);
-            }
-        }
-        drop(inner);
+        debug!("loop process, {:?}", after_poll.elapsed());
     }
 
     fn consume_timeouts(&mut self, now: Instant) {
@@ -396,14 +337,14 @@ impl Core {
     /// that the `CURRENT_LOOP` variable is set appropriately.
     fn notify_handle(&self, handle: Task) {
         debug!("notifying a task handle");
-        CURRENT_LOOP.set(&self, || handle.notify());
+        CURRENT_LOOP.set(self, || handle.notify());
     }
 
     fn consume_queue(&self) {
         debug!("consuming notification queue");
         // TODO: can we do better than `.unwrap()` here?
         loop {
-            let msg = self.rx.borrow_mut().poll_stream_notify(&self.rx_readiness, 0).unwrap();
+            let msg = self.rx.borrow_mut().poll_stream_notify(&self.notify_rx, 0).unwrap();
             match msg {
                 Async::Ready(Some(msg)) => self.notify(msg),
                 Async::NotReady |
@@ -414,13 +355,6 @@ impl Core {
 
     fn notify(&self, msg: Message) {
         match msg {
-            Message::DropSource(tok) => self.inner.borrow_mut().drop_source(tok),
-            Message::Schedule(tok, wake, dir) => {
-                let task = self.inner.borrow_mut().schedule(tok, wake, dir);
-                if let Some(task) = task {
-                    self.notify_handle(task);
-                }
-            }
             Message::UpdateTimeout(t, handle) => {
                 let task = self.inner.borrow_mut().update_timeout(t, handle);
                 if let Some(task) = task {
@@ -439,7 +373,7 @@ impl Core {
 
     /// Get the ID of this loop
     pub fn id(&self) -> CoreId {
-        CoreId(self.inner.borrow().id)
+        CoreId(self.id)
     }
 }
 
@@ -460,58 +394,6 @@ impl fmt::Debug for Core {
 }
 
 impl Inner {
-    fn add_source(&mut self, source: &Evented)
-                  -> io::Result<(Arc<AtomicUsize>, usize)> {
-        debug!("adding a new I/O source");
-        let sched = ScheduledIo {
-            readiness: Arc::new(AtomicUsize::new(0)),
-            reader: None,
-            writer: None,
-        };
-        if self.io_dispatch.len() == self.io_dispatch.capacity() {
-            let amt = self.io_dispatch.len();
-            self.io_dispatch.reserve_exact(amt);
-        }
-        let entry = self.io_dispatch.vacant_entry();
-        let key = entry.key();
-        try!(self.io.register(source,
-                              mio::Token(TOKEN_START + key * 2),
-                              mio::Ready::readable() |
-                                mio::Ready::writable() |
-                                platform::all(),
-                              mio::PollOpt::edge()));
-        let sched = entry.insert(sched);
-        Ok((sched.readiness.clone(), key))
-    }
-
-    fn deregister_source(&mut self, source: &Evented) -> io::Result<()> {
-        self.io.deregister(source)
-    }
-
-    fn drop_source(&mut self, token: usize) {
-        debug!("dropping I/O source: {}", token);
-        self.io_dispatch.remove(token);
-    }
-
-    fn schedule(&mut self, token: usize, wake: Task, dir: Direction)
-                -> Option<Task> {
-        debug!("scheduling direction for: {}", token);
-        let sched = self.io_dispatch.get_mut(token).unwrap();
-        let (slot, ready) = match dir {
-            Direction::Read => (&mut sched.reader, !mio::Ready::writable()),
-            Direction::Write => (&mut sched.writer, mio::Ready::writable()),
-        };
-        if sched.readiness.load(Ordering::SeqCst) & ready2usize(ready) != 0 {
-            debug!("cancelling block");
-            *slot = None;
-            Some(wake)
-        } else {
-            debug!("blocking");
-            *slot = Some(wake);
-            None
-        }
-    }
-
     fn add_timeout(&mut self, at: Instant) -> usize {
         if self.timeouts.len() == self.timeouts.capacity() {
             let len = self.timeouts.len();
@@ -550,28 +432,6 @@ impl Inner {
             self.timer_heap.remove(slot);
         }
     }
-
-    fn spawn(&mut self, future: Box<Future<Item=(), Error=()>>) {
-        if self.task_dispatch.len() == self.task_dispatch.capacity() {
-            let len = self.task_dispatch.len();
-            self.task_dispatch.reserve_exact(len);
-        }
-        let entry = self.task_dispatch.vacant_entry();
-        let token = TOKEN_START + 2 * entry.key() + 1;
-        let pair = mio::Registration::new2();
-        self.io.register(&pair.0,
-                         mio::Token(token),
-                         mio::Ready::readable(),
-                         mio::PollOpt::level())
-            .expect("cannot fail future registration with mio");
-        let unpark = Arc::new(MySetReadiness(pair.1));
-        unpark.notify(0);
-        entry.insert(ScheduledTask {
-            spawn: Some(executor::spawn(future)),
-            wake: Some(unpark),
-            _registration: pair.0,
-        });
-    }
 }
 
 impl Remote {
@@ -592,7 +452,7 @@ impl Remote {
                     // comes back false then we know for sure there are no
                     // pending messages, so we can immediately deliver our
                     // message.
-                    if lp.rx_readiness.0.readiness().is_readable() {
+                    if lp.notify_rx.take() {
                         lp.consume_queue();
                     }
                     lp.notify(msg);
@@ -616,7 +476,7 @@ impl Remote {
     {
         if CURRENT_LOOP.is_set() {
             CURRENT_LOOP.with(|lp| {
-                let same = lp.inner.borrow().id == self.id;
+                let same = lp.id == self.id;
                 if same {
                     f(Some(lp))
                 } else {
@@ -649,7 +509,7 @@ impl Remote {
     {
         self.send(Message::Run(Box::new(|lp: &Core| {
             let f = f(&lp.handle());
-            lp.inner.borrow_mut().spawn(Box::new(f.into_future()));
+            lp.handle().spawn(f.into_future());
         })));
     }
 
@@ -673,7 +533,7 @@ impl Remote {
     pub fn handle(&self) -> Option<Handle> {
         if CURRENT_LOOP.is_set() {
             CURRENT_LOOP.with(|lp| {
-                let same = lp.inner.borrow().id == self.id;
+                let same = lp.id == self.id;
                 if same {
                     Some(lp.handle())
                 } else {
@@ -704,6 +564,11 @@ impl fmt::Debug for Remote {
 }
 
 impl Handle {
+    /// Returns a reference to the new Tokio handle
+    pub fn new_tokio_handle(&self) -> &::tokio::reactor::Handle {
+        &self.remote.new_handle
+    }
+
     /// Returns a reference to the underlying remote handle to the event loop.
     pub fn remote(&self) -> &Remote {
         &self.remote
@@ -719,11 +584,24 @@ impl Handle {
     pub fn spawn<F>(&self, f: F)
         where F: Future<Item=(), Error=()> + 'static,
     {
+        use tokio_executor::Executor;
+
         let inner = match self.inner.upgrade() {
             Some(inner) => inner,
-            None => return,
+            None => {
+                return;
+            }
         };
-        inner.borrow_mut().spawn(Box::new(f));
+
+        // Try accessing the executor directly
+        if let Ok(mut inner) = inner.try_borrow_mut() {
+            inner.pending_spawn.push(Box::new(f));
+            return;
+        }
+
+        // If that doesn't work, the executor is probably active, so spawn using
+        // the global fn.
+        TaskExecutor::current().spawn_local(Box::new(f));
     }
 
     /// Spawns a closure on this event loop.
@@ -787,12 +665,28 @@ impl TimeoutState {
     }
 }
 
-struct MySetReadiness(mio::SetReadiness);
+struct MyNotify {
+    unpark: UnparkThread,
+    notified: AtomicBool,
+}
 
-impl Notify for MySetReadiness {
-    fn notify(&self, _id: usize) {
-        self.0.set_readiness(mio::Ready::readable())
-              .expect("failed to set readiness");
+impl MyNotify {
+    fn new(unpark: UnparkThread) -> Self {
+        MyNotify {
+            unpark,
+            notified: AtomicBool::new(true),
+        }
+    }
+
+    fn take(&self) -> bool {
+        self.notified.swap(false, Ordering::SeqCst)
+    }
+}
+
+impl Notify for MyNotify {
+    fn notify(&self, _: usize) {
+        self.notified.store(true, Ordering::SeqCst);
+        self.unpark.unpark();
     }
 }
 

--- a/src/reactor/poll_evented.rs
+++ b/src/reactor/poll_evented.rs
@@ -349,7 +349,7 @@ impl<E> PollEvented<E> {
 
 impl<E: Read> Read for PollEvented<E> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if let Async::NotReady = self.poll_read() {
+        if let Async::NotReady = PollEvented::poll_read(self) {
             return Err(io::ErrorKind::WouldBlock.into())
         }
 
@@ -365,7 +365,7 @@ impl<E: Read> Read for PollEvented<E> {
 
 impl<E: Write> Write for PollEvented<E> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        if let Async::NotReady = self.poll_write() {
+        if let Async::NotReady = PollEvented::poll_write(self) {
             return Err(io::ErrorKind::WouldBlock.into())
         }
 
@@ -379,7 +379,7 @@ impl<E: Write> Write for PollEvented<E> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        if let Async::NotReady = self.poll_write() {
+        if let Async::NotReady = PollEvented::poll_write(self) {
             return Err(io::ErrorKind::WouldBlock.into())
         }
 
@@ -417,7 +417,7 @@ impl<'a, E> Read for &'a PollEvented<E>
     where &'a E: Read,
 {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if let Async::NotReady = self.poll_read() {
+        if let Async::NotReady = PollEvented::poll_read(self) {
             return Err(io::ErrorKind::WouldBlock.into())
         }
 
@@ -435,7 +435,7 @@ impl<'a, E> Write for &'a PollEvented<E>
     where &'a E: Write,
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        if let Async::NotReady = self.poll_write() {
+        if let Async::NotReady = PollEvented::poll_write(self) {
             return Err(io::ErrorKind::WouldBlock.into())
         }
 
@@ -449,7 +449,7 @@ impl<'a, E> Write for &'a PollEvented<E>
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        if let Async::NotReady = self.poll_write() {
+        if let Async::NotReady = PollEvented::poll_write(self) {
             return Err(io::ErrorKind::WouldBlock.into())
         }
 


### PR DESCRIPTION
This depends on https://github.com/tokio-rs/tokio/pull/160.

Tokio reform was released as a separate crate (`tokio`). However, the
ecosystem has been split as tokio-core is not compatible with tokio.
Libraries (like hyper) that expose tokio-core as part of the public API
cannot easily switch to tokio as is.

This patch updates tokio-core to use tokio internally. This should help
reduce the friction encountered when users attempt to update their code
bases to tokio.