### PR TITLE
Fix PollEvented

### DIFF
--- a/src/reactor/poll_evented.rs
+++ b/src/reactor/poll_evented.rs
@@ -88,7 +88,7 @@ impl<E: Evented> PollEvented<E> {
     /// when it's ready.
     pub fn new(io: E, handle: &Handle) -> io::Result<PollEvented<E>> {
         let registration = Registration::new();
-        registration.register(&io)?;
+        registration.register_with(&io, handle.new_tokio_handle())?;
 
         Ok(PollEvented {
             io: io,


### PR DESCRIPTION
During the internal refactor to use the `tokio` crate,
`PollEvented::new` stopped using the specified `&Handle`. This resulted
in the `PollEvented` instance being registered with the fallback
reactor.

This patch fixes `PollEvented::new` to use the specified reactor.

Fixes #307